### PR TITLE
Kube infra + persistence test

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ DEPLOY_MODE=kube BASE_URL=http://localhost:8080 bash test-scripts/run_all.sh
 ### Deletion of the stack
 
 ```bash
-helm uninstall redis nginx
+helm uninstall order-redis stock-redis payment-redis nginx
 kubectl delete -f k8s/
 kubectl delete configmap gateway-nginx-conf
 kubectl delete pvc --all
@@ -367,6 +367,7 @@ BASE_URL=http://192.168.1.100:8000 bash test-scripts/run_all.sh
 | `07_mode_flag.sh` | Switches `CHECKOUT_MODE` between `saga` and `2pc` at runtime; both modes produce correct end-to-end results and correct compensation |
 | `08_consistency_check.sh` | Fires 10 concurrent checkouts against the same item; verifies no negative stock/credit and no lost updates |
 | `09_2pc_protocol.sh` | Directly exercises all 2PC participant endpoints: prepare/commit/abort idempotency, double-spend prevention under reservations, reservation conflict detection |
+| `10_redis_aof_persistence.sh` | Crashes all three Redis masters and verifies stock, credit, and order data is fully restored on restart — proving AOF persistence works end-to-end |
 <!-- | `06_fault_redis_master.sh` | Kills each Redis master; Sentinel promotes replica within 8 s; checkout uninterrupted *(disabled in `run_all.sh` by default — run manually)* | #TODO -->
 
 ## Technology stack

--- a/README.md
+++ b/README.md
@@ -249,6 +249,45 @@ curl -s http://localhost:8000/stock/find/0
 curl -s http://localhost:8000/payment/find_user/$USER
 ```
 
+### Kubernetes — minikube (local)
+
+**Prerequisites:** minikube, helm, kubectl, docker
+
+```bash
+# 1. Start minikube
+minikube start
+
+# 2. Build images + install Helm charts (Redis + nginx ingress) + apply all manifests
+bash deploy-charts-minikube.sh
+
+# 3. Watch pods come up (all should reach Running 1/1)
+kubectl get pods -w
+```
+
+Once all pods are `Running`, forward the ingress port in a separate terminal, then run the tests:
+
+```bash
+# Terminal 1 — keep running
+kubectl port-forward -n ingress-nginx svc/ingress-nginx-controller 8080:80
+
+# Terminal 2
+DEPLOY_MODE=kube BASE_URL=http://localhost:8080 bash test-scripts/run_all.sh
+```
+
+### Deletion of the stack
+
+```bash
+helm uninstall redis nginx
+kubectl delete -f k8s/
+kubectl delete configmap gateway-nginx-conf
+kubectl delete pvc --all
+```
+
+Or to destroy the entire minikube cluster:
+```bash
+minikube delete
+```
+
 
 ## Configuration
 

--- a/deploy-charts-cluster.sh
+++ b/deploy-charts-cluster.sh
@@ -6,8 +6,10 @@ helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 helm repo update
 
-# 2. Install Redis with custom values
-helm upgrade --install redis bitnami/redis -f helm-config/redis-helm-values.yaml
+# 2. Install one Redis instance per service (mirrors the docker-compose architecture)
+helm upgrade --install order-redis   bitnami/redis -f helm-config/redis-helm-values.yaml
+helm upgrade --install stock-redis   bitnami/redis -f helm-config/redis-helm-values.yaml
+helm upgrade --install payment-redis bitnami/redis -f helm-config/redis-helm-values.yaml
 
 # 3. Install nginx ingress controller with custom values
 helm upgrade --install nginx ingress-nginx/ingress-nginx -f helm-config/nginx-helm-values.yaml

--- a/deploy-charts-cluster.sh
+++ b/deploy-charts-cluster.sh
@@ -1,9 +1,21 @@
 #!/usr/bin/env bash
+set -e   # exit immediately if any command fails
 
+# 1. Install Helm charts: Redis and nginx ingress controller
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
-
 helm repo update
 
-helm install -f helm-config/redis-helm-values.yaml redis bitnami/redis
-helm install -f helm-config/nginx-helm-values.yaml nginx ingress-nginx/ingress-nginx
+# 2. Install Redis with custom values
+helm upgrade --install redis bitnami/redis -f helm-config/redis-helm-values.yaml
+
+# 3. Install nginx ingress controller with custom values
+helm upgrade --install nginx ingress-nginx/ingress-nginx -f helm-config/nginx-helm-values.yaml
+
+# 4. Create configmap for internal nginx gateway
+kubectl create configmap gateway-nginx-conf \
+  --from-file=nginx.conf=k8s/gateway-nginx.conf \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# 5. Deploy the gateway and app services
+kubectl apply -f k8s/

--- a/deploy-charts-minikube.sh
+++ b/deploy-charts-minikube.sh
@@ -1,15 +1,24 @@
 #!/usr/bin/env bash
 set -e   # exit immediately if any command fails
 
-# 1. Install Redis and nginx ingress controller with Helm
+# 1. Build service images into minikube's Docker daemon
+eval $(minikube docker-env)
+docker build -t order:latest ./order
+docker build -t stock:latest ./stock
+docker build -t payment:latest ./payment
+
+# 2. Install Redis with Helm
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo update
-helm upgrade --install redis bitnami/redis -f helm-config/redis-helm-values.yaml
+helm upgrade --install redis bitnami/redis -f helm-config/redis-helm-values-minikube.yaml
 
-# 2. Create configmap for internal nginx gateway
+# 3. Enable the minikube ingress addon
+minikube addons enable ingress
+
+# 4. Create configmap for internal nginx gateway
 kubectl create configmap gateway-nginx-conf \
   --from-file=nginx.conf=k8s/gateway-nginx.conf \
   --dry-run=client -o yaml | kubectl apply -f -
 
-# 3. Deploy the gateway and app services
+# 5. Deploy the gateway and app services
 kubectl apply -f k8s/

--- a/deploy-charts-minikube.sh
+++ b/deploy-charts-minikube.sh
@@ -7,10 +7,12 @@ docker build -t order:latest ./order
 docker build -t stock:latest ./stock
 docker build -t payment:latest ./payment
 
-# 2. Install Redis with Helm
+# 2. Install one Redis instance per service (mirrors the docker-compose architecture)
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo update
-helm upgrade --install redis bitnami/redis -f helm-config/redis-helm-values-minikube.yaml
+helm upgrade --install order-redis   bitnami/redis -f helm-config/redis-helm-values-minikube.yaml
+helm upgrade --install stock-redis   bitnami/redis -f helm-config/redis-helm-values-minikube.yaml
+helm upgrade --install payment-redis bitnami/redis -f helm-config/redis-helm-values-minikube.yaml
 
 # 3. Enable the minikube ingress addon
 minikube addons enable ingress

--- a/deploy-charts-minikube.sh
+++ b/deploy-charts-minikube.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
+set -e   # exit immediately if any command fails
 
+# 1. Install Redis and nginx ingress controller with Helm
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo update
+helm upgrade --install redis bitnami/redis -f helm-config/redis-helm-values.yaml
 
-helm install -f helm-config/redis-helm-values.yaml redis bitnami/redis
+# 2. Create configmap for internal nginx gateway
+kubectl create configmap gateway-nginx-conf \
+  --from-file=nginx.conf=k8s/gateway-nginx.conf \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# 3. Deploy the gateway and app services
+kubectl apply -f k8s/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     image: order:latest
     environment:
       - GATEWAY_URL=http://gateway:80
+      - PROTOCOL=saga
     command: gunicorn -b 0.0.0.0:5000 -w 2 --timeout 30 --log-level=info app:app
     env_file:
       - env/order_redis.env
@@ -25,7 +26,9 @@ services:
 
   order-db:
     image: redis:7.2-bookworm
-    command: redis-server --requirepass redis --maxmemory 512mb
+    command: redis-server --requirepass redis --maxmemory 512mb --appendonly yes --appendfsync everysec
+    volumes:
+      - order-db-data:/data
 
   stock-service:
     build: ./stock
@@ -38,7 +41,9 @@ services:
 
   stock-db:
     image: redis:7.2-bookworm
-    command: redis-server --requirepass redis --maxmemory 512mb
+    command: redis-server --requirepass redis --maxmemory 512mb --appendonly yes --appendfsync everysec
+    volumes:
+      - stock-db-data:/data
 
   payment-service:
     build: ./payment
@@ -51,4 +56,11 @@ services:
 
   payment-db:
     image: redis:7.2-bookworm
-    command: redis-server --requirepass redis --maxmemory 512mb
+    command: redis-server --requirepass redis --maxmemory 512mb --appendonly yes --appendfsync everysec
+    volumes:
+      - payment-db-data:/data
+
+volumes:
+  order-db-data:
+  stock-db-data:
+  payment-db-data:

--- a/documents/task-split.md
+++ b/documents/task-split.md
@@ -59,6 +59,7 @@
 * **K8s & Persistence:** Setup manifests with resource limits and configure Redis AOF (Append Only File) to prevent data loss on DB restart.
 * **Chaos Testing:** Create scripts to kill containers at specific moments (e.g., after a 2PC Prepare but before Commit) to verify Member C's logic.
 * **Performance:** Run Locust and the wdm-benchmark to compare 2PC latency versus Saga latency under load.
+* TODO: Redis sentinal look into it
 
 ### Phase 2
 * **Artifact Packaging:** Lead the creation of the standalone Python package for the Orchestrator.

--- a/helm-config/redis-helm-values-minikube.yaml
+++ b/helm-config/redis-helm-values-minikube.yaml
@@ -1,0 +1,33 @@
+# Redis Helm overrides for local minikube testing.
+# Replaces the resource requests in redis-helm-values.yaml with smaller values
+# so Redis fits on a single-node minikube cluster.
+
+auth:
+  password: redis
+
+commonConfiguration: |-
+  appendonly yes
+  appendfsync everysec
+
+master:
+  persistence:
+    size: 1Gi
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 100m
+    limits:
+      memory: 512Mi
+      cpu: 500m
+
+replica:
+  replicaCount: 1
+  persistence:
+    size: 1Gi
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 100m
+    limits:
+      memory: 512Mi
+      cpu: 500m

--- a/helm-config/redis-helm-values.yaml
+++ b/helm-config/redis-helm-values.yaml
@@ -1,5 +1,20 @@
+# =============================================================================
+# Redis Helm Chart Values (bitnami/redis)
+# =============================================================================
+# Shared Redis instance (1 master + 1 replica) with AOF persistence enabled.
+# Each service uses a separate logical database to avoid key collisions:
+#   order=DB0, stock=DB1, payment=DB2
+# =============================================================================
+
 auth:
   password: redis
+
+# appendonly enable: AOF persistence (survives container restart)
+# appendfsync everysec: flush to disk once per second (max 1s data loss)
+commonConfiguration: |-
+  appendonly yes
+  appendfsync everysec
+
 master:
   persistence:
     size: 4Gi
@@ -7,6 +22,7 @@ master:
     requests:
       memory: 4Gi
       cpu: 2
+
 replica:
   replicaCount: 1
   persistence:

--- a/helm-config/redis-helm-values.yaml
+++ b/helm-config/redis-helm-values.yaml
@@ -1,9 +1,8 @@
 # =============================================================================
 # Redis Helm Chart Values (bitnami/redis)
 # =============================================================================
-# Shared Redis instance (1 master + 1 replica) with AOF persistence enabled.
-# Each service uses a separate logical database to avoid key collisions:
-#   order=DB0, stock=DB1, payment=DB2
+# Redis instance (1 master + 1 replica) with AOF persistence enabled.
+# Deployed once per service (order-redis, stock-redis, payment-redis).
 # =============================================================================
 
 auth:

--- a/k8s/gateway-nginx.conf
+++ b/k8s/gateway-nginx.conf
@@ -1,0 +1,31 @@
+# nginx config for the internal K8s gateway pod.
+# Identical to gateway_nginx.conf (used by docker-compose) except the payment
+# upstream uses "user-service" — the K8s Service name from the original template.
+
+events { worker_connections 2048;}
+
+http {
+    upstream order-app {
+        server order-service:5000;
+    }
+    upstream payment-app {
+        server user-service:5000;
+    }
+    upstream stock-app {
+        server stock-service:5000;
+    }
+    server {
+        listen 80;
+        location /orders/ {
+           proxy_pass   http://order-app/;
+        }
+        location /payment/ {
+           proxy_pass   http://payment-app/;
+        }
+        location /stock/ {
+           proxy_pass   http://stock-app/;
+        }
+        access_log  /var/log/nginx/server.access.log;
+    }
+    access_log  /var/log/nginx/access.log;
+}

--- a/k8s/gateway-nginx.conf
+++ b/k8s/gateway-nginx.conf
@@ -1,6 +1,5 @@
 # nginx config for the internal K8s gateway pod.
-# Identical to gateway_nginx.conf (used by docker-compose) except the payment
-# upstream uses "user-service" — the K8s Service name from the original template.
+# Mirrors gateway_nginx.conf (used by docker-compose).
 
 events { worker_connections 2048;}
 
@@ -9,7 +8,7 @@ http {
         server order-service:5000;
     }
     upstream payment-app {
-        server user-service:5000;
+        server payment-service:5000;
     }
     upstream stock-app {
         server stock-service:5000;

--- a/k8s/gateway.yaml
+++ b/k8s/gateway.yaml
@@ -1,0 +1,81 @@
+# =============================================================================
+# NGINX GATEWAY — Kubernetes Manifests
+# =============================================================================
+# Internal reverse proxy that mirrors the docker-compose "gateway" service.
+# Routes the order service's outbound calls (/stock/, /payment/) to the correct
+# pods inside the cluster. Config is mounted from the "gateway-nginx-conf"
+# ConfigMap, which the deploy scripts create from k8s/gateway-nginx.conf.
+# =============================================================================
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway
+spec:
+  type: ClusterIP
+  selector:
+    component: gateway
+  ports:
+    - port: 80
+      name: http
+      targetPort: 80
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: gateway
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  template:
+    metadata:
+      labels:
+        component: gateway
+    spec:
+      containers:
+        - name: gateway
+          image: nginx:1.25-bookworm
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "250m"
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            tcpSocket:
+              port: 80
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: 80
+            initialDelaySeconds: 5
+            periodSeconds: 30
+            failureThreshold: 3
+
+          # Mount the ConfigMap (created from k8s/gateway-nginx.conf by the deploy
+          # script) as /etc/nginx/nginx.conf inside the container.
+          # subPath mounts only the "nginx.conf" key, not the whole directory.
+          volumeMounts:
+            - name: nginx-conf
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+
+      volumes:
+        - name: nginx-conf
+          configMap:
+            name: gateway-nginx-conf

--- a/k8s/ingress-service.yaml
+++ b/k8s/ingress-service.yaml
@@ -3,30 +3,30 @@ kind: Ingress
 metadata:
  name: ingress-service
  annotations:
-   kubernetes.io/ingress.class: nginx
    nginx.ingress.kubernetes.io/rewrite-target: /$1
 spec:
+ ingressClassName: nginx
  rules:
    - http:
       paths:
         - path: /orders/?(.*)
-          pathType: Prefix
+          pathType: ImplementationSpecific
           backend:
             service:
               name: order-service
               port:
                 number: 5000
         - path: /stock/?(.*)
-          pathType: Prefix
+          pathType: ImplementationSpecific
           backend:
             service:
               name: stock-service
               port:
                 number: 5000
         - path: /payment/?(.*)
-          pathType: Prefix
+          pathType: ImplementationSpecific
           backend:
             service:
-              name: user-service
+              name: payment-service
               port:
                 number: 5000

--- a/k8s/order-app.yaml
+++ b/k8s/order-app.yaml
@@ -46,6 +46,7 @@ spec:
       containers:
         - name: order
           image: order:latest
+          imagePullPolicy: Never
           resources:
             requests:
               memory: "256Mi"

--- a/k8s/order-app.yaml
+++ b/k8s/order-app.yaml
@@ -1,3 +1,11 @@
+# =============================================================================
+# ORDER SERVICE — Kubernetes Manifests
+# =============================================================================
+# The order service is the transaction COORDINATOR. It is the entry point for
+# checkouts and will orchestrate either a Saga or 2PC across the stock and
+# payment services (depending on the PROTOCOL env var).
+# =============================================================================
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,7 +18,9 @@ spec:
     - port: 5000
       name: http
       targetPort: 5000
+
 ---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -20,6 +30,11 @@ spec:
   selector:
     matchLabels:
       component: order
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   template:
     metadata:
       labels:
@@ -29,25 +44,39 @@ spec:
         - name: order
           image: order:latest
           resources:
-            limits:
-              memory: "1Gi"
-              cpu: "1"
             requests:
-              memory: "1Gi"
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
               cpu: "1"
           command: ["gunicorn"]
-          args: ["-b", "0.0.0.0:5000", "app:app"]
+          args: ["-b", "0.0.0.0:5000", "-w", "2", "--timeout", "30",
+                 "--log-level", "info", "app:app"]
           ports:
             - containerPort: 5000
+          readinessProbe:
+            tcpSocket:
+              port: 5000
+            initialDelaySeconds: 5 
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: 5000
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            failureThreshold: 3
+
           env:
-            - name: USER_SERVICE_URL
-              value: "user-service"
-            - name: STOCK_SERVICE_URL
-              value: "stock-service"
+            - name: PROTOCOL
+              value: "saga"          # Which protocol to use: "saga" or "2pc"
+            - name: GATEWAY_URL
+              value: "http://gateway:80"
             - name: REDIS_HOST
-              value: redis-master
+              value: "redis-master"
             - name: REDIS_PORT
-              value: '6379'
+              value: "6379"
             - name: REDIS_PASSWORD
               value: "redis"
             - name: REDIS_DB

--- a/k8s/order-app.yaml
+++ b/k8s/order-app.yaml
@@ -77,10 +77,10 @@ spec:
             - name: GATEWAY_URL
               value: "http://gateway:80"
             - name: REDIS_HOST
-              value: "redis-master"
+              value: "order-redis-master"
             - name: REDIS_PORT
               value: "6379"
             - name: REDIS_PASSWORD
               value: "redis"
             - name: REDIS_DB
-              value: "0"            # order=DB0, stock=DB1, payment=DB2 (shared Redis)
+              value: "0"

--- a/k8s/payment-app.yaml
+++ b/k8s/payment-app.yaml
@@ -77,10 +77,10 @@ spec:
 
           env:
             - name: REDIS_HOST
-              value: "redis-master"
+              value: "payment-redis-master"
             - name: REDIS_PORT
               value: "6379"
             - name: REDIS_PASSWORD
               value: "redis"
             - name: REDIS_DB
-              value: "2"
+              value: "0"

--- a/k8s/payment-app.yaml
+++ b/k8s/payment-app.yaml
@@ -7,11 +7,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: user-service
+  name: payment-service
 spec:
   type: ClusterIP
   selector:
-    component: user
+    component: payment
   ports:
     - port: 5000
       name: http
@@ -22,13 +22,13 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: user-deployment
+  name: payment-deployment
 spec:
   replicas: 2
 
   selector:
     matchLabels:
-      component: user
+      component: payment
 
   strategy:
     type: RollingUpdate
@@ -39,11 +39,12 @@ spec:
   template:
     metadata:
       labels:
-        component: user
+        component: payment
     spec:
       containers:
-        - name: user
-          image: user:latest
+        - name: payment
+          image: payment:latest
+          imagePullPolicy: Never
 
           resources:
             requests:

--- a/k8s/stock-app.yaml
+++ b/k8s/stock-app.yaml
@@ -25,7 +25,7 @@ kind: Deployment
 metadata:
   name: stock-deployment
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       component: stock
@@ -50,7 +50,7 @@ spec:
               memory: "512Mi"
               cpu: "1"
           command: ["gunicorn"]
-          args: ["-b", "0.0.0.0:5000", "-w", "2", "--timeout", "30",
+          args: ["-b", "0.0.0.0:5000", "-w", "4", "--timeout", "30",
                  "--log-level", "info", "app:app"]
           ports:
             - containerPort: 5000

--- a/k8s/stock-app.yaml
+++ b/k8s/stock-app.yaml
@@ -1,3 +1,10 @@
+# =============================================================================
+# STOCK SERVICE — Kubernetes Manifests
+# =============================================================================
+# The stock service is a 2PC/Saga PARTICIPANT. It manages item inventory and
+# will either reserve or release stock based on messages from the order service.
+# =============================================================================
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,7 +17,9 @@ spec:
     - port: 5000
       name: http
       targetPort: 5000
+
 ---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -20,6 +29,11 @@ spec:
   selector:
     matchLabels:
       component: stock
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   template:
     metadata:
       labels:
@@ -29,22 +43,35 @@ spec:
         - name: stock
           image: stock:latest
           resources:
-            limits:
-              memory: "1Gi"
-              cpu: "1"
             requests:
-              memory: "1Gi"
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
               cpu: "1"
           command: ["gunicorn"]
-          args: ["-b", "0.0.0.0:5000", "app:app"]
+          args: ["-b", "0.0.0.0:5000", "-w", "2", "--timeout", "30",
+                 "--log-level", "info", "app:app"]
           ports:
             - containerPort: 5000
+          readinessProbe:
+            tcpSocket:
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: 5000
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            failureThreshold: 3
           env:
             - name: REDIS_HOST
-              value: redis-master
+              value: "redis-master"
             - name: REDIS_PORT
-              value: '6379'
+              value: "6379"
             - name: REDIS_PASSWORD
               value: "redis"
             - name: REDIS_DB
-              value: "0"
+              value: "1"

--- a/k8s/stock-app.yaml
+++ b/k8s/stock-app.yaml
@@ -42,6 +42,7 @@ spec:
       containers:
         - name: stock
           image: stock:latest
+          imagePullPolicy: Never
           resources:
             requests:
               memory: "256Mi"

--- a/k8s/stock-app.yaml
+++ b/k8s/stock-app.yaml
@@ -69,10 +69,10 @@ spec:
             failureThreshold: 3
           env:
             - name: REDIS_HOST
-              value: "redis-master"
+              value: "stock-redis-master"
             - name: REDIS_PORT
               value: "6379"
             - name: REDIS_PASSWORD
               value: "redis"
             - name: REDIS_DB
-              value: "1"
+              value: "0"

--- a/k8s/user-app.yaml
+++ b/k8s/user-app.yaml
@@ -24,7 +24,7 @@ kind: Deployment
 metadata:
   name: user-deployment
 spec:
-  replicas: 1
+  replicas: 2
 
   selector:
     matchLabels:
@@ -54,7 +54,7 @@ spec:
               cpu: "1"
 
           command: ["gunicorn"]
-          args: ["-b", "0.0.0.0:5000", "-w", "2", "--timeout", "30",
+          args: ["-b", "0.0.0.0:5000", "-w", "4", "--timeout", "30",
                  "--log-level", "info", "app:app"]
 
           ports:

--- a/k8s/user-app.yaml
+++ b/k8s/user-app.yaml
@@ -1,3 +1,9 @@
+# =============================================================================
+# PAYMENT SERVICE — Kubernetes Manifests
+# =============================================================================
+# The payment service is a 2PC/Saga PARTICIPANT. It manages user credit.
+# =============================================================================
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -10,16 +16,26 @@ spec:
     - port: 5000
       name: http
       targetPort: 5000
+
 ---
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: user-deployment
 spec:
   replicas: 1
+
   selector:
     matchLabels:
       component: user
+
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+
   template:
     metadata:
       labels:
@@ -28,23 +44,42 @@ spec:
       containers:
         - name: user
           image: user:latest
+
           resources:
-            limits:
-              memory: "1Gi"
-              cpu: "1"
             requests:
-              memory: "1Gi"
+              memory: "256Mi"
+              cpu: "250m"
+            limits:
+              memory: "512Mi"
               cpu: "1"
+
           command: ["gunicorn"]
-          args: ["-b", "0.0.0.0:5000", "app:app"]
+          args: ["-b", "0.0.0.0:5000", "-w", "2", "--timeout", "30",
+                 "--log-level", "info", "app:app"]
+
           ports:
             - containerPort: 5000
+
+          readinessProbe:
+            tcpSocket:
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 3
+
+          livenessProbe:
+            tcpSocket:
+              port: 5000
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            failureThreshold: 3
+
           env:
             - name: REDIS_HOST
-              value: redis-master
+              value: "redis-master"
             - name: REDIS_PORT
-              value: '6379'
+              value: "6379"
             - name: REDIS_PASSWORD
               value: "redis"
             - name: REDIS_DB
-              value: "0"
+              value: "2"

--- a/test-scripts/05_fault_app_replica.sh
+++ b/test-scripts/05_fault_app_replica.sh
@@ -10,7 +10,7 @@ SERVICES=("order-service-1" "order-service-2" "stock-service-1" "stock-service-2
 
 for SERVICE in "${SERVICES[@]}"; do
   yellow "Stopping $SERVICE..."
-  docker compose stop "$SERVICE" > /dev/null 2>&1
+  service_stop "$SERVICE"
   sleep 2  # let nginx detect the failure
 
   USER_ID=$(create_funded_user 200)
@@ -19,7 +19,7 @@ for SERVICE in "${SERVICES[@]}"; do
   assert_http "Checkout works with $SERVICE down" "200" "$CODE"
 
   yellow "Restarting $SERVICE..."
-  docker compose start "$SERVICE" > /dev/null 2>&1
+  service_start "$SERVICE"
   sleep 3
 done
 

--- a/test-scripts/07_mode_flag.sh
+++ b/test-scripts/07_mode_flag.sh
@@ -14,40 +14,8 @@ header "TEST 7 — Mode Flag (SAGA vs 2PC)"
 
 seed_data
 
-# ── Helpers ───────────────────────────────────────────────────────────────────
-
-_set_checkout_mode() {
-  local mode="$1"
-  local override="/tmp/checkout_mode_override_$$.yml"
-
-  # Map-format override so docker compose MERGES rather than replaces the
-  # base service environment (list format would wipe REDIS_HOST etc.).
-  cat > "$override" <<YAML
-services:
-  order-service-1:
-    environment:
-      CHECKOUT_MODE: "${mode}"
-  order-service-2:
-    environment:
-      CHECKOUT_MODE: "${mode}"
-YAML
-
-  docker compose stop order-service-1 order-service-2 > /dev/null 2>&1
-
-  if [ "$mode" = "saga" ]; then
-    # Restore from the canonical compose file (no override needed).
-    docker compose up -d --no-deps order-service-1 order-service-2 > /dev/null 2>&1
-  else
-    docker compose -f docker-compose.yml -f "$override" \
-      up -d --no-deps order-service-1 order-service-2 > /dev/null 2>&1
-  fi
-
-  rm -f "$override"
-  sleep 4  # allow gunicorn workers to start and run 2PC recovery
-}
-
 # Always restore saga mode on script exit so subsequent tests are unaffected.
-_restore_saga() { _set_checkout_mode saga 2>/dev/null; }
+_restore_saga() { set_checkout_mode saga 2>/dev/null; }
 trap _restore_saga EXIT
 
 # ── Section A: SAGA end-to-end ────────────────────────────────────────────────
@@ -76,7 +44,7 @@ assert_lte "SAGA credit decreased" "$CREDIT_BEFORE" "$CREDIT_AFTER"
 # ── Section B: 2PC end-to-end ─────────────────────────────────────────────────
 
 yellow "[ B ] Switching to CHECKOUT_MODE=2pc..."
-_set_checkout_mode 2pc
+set_checkout_mode 2pc
 yellow "    Order services restarted with CHECKOUT_MODE=2pc"
 
 USER_2PC=$(create_funded_user 200)
@@ -125,7 +93,7 @@ assert_eq "2PC failed order.status = failed" "failed" "$STATUS_BROKE"
 # ── Restore saga (trap also fires on exit, this is belt-and-suspenders) ───────
 
 yellow "[ D ] Restoring CHECKOUT_MODE=saga..."
-_set_checkout_mode saga
+set_checkout_mode saga
 yellow "    Order services restored"
 
 USER_SAGA2=$(create_funded_user 200)

--- a/test-scripts/10_redis_aof_persistence.sh
+++ b/test-scripts/10_redis_aof_persistence.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Test 10: AOF persistence — crash a Redis master and verify data survives restart.
+#
+# Redis replays the AOF log on startup, so all writes made before the crash
+# should be fully restored. This test proves that "appendonly yes" is actually
+# working and not just set in config.
+#
+# Only runs in DEPLOY_MODE=docker (docker compose gives direct control over
+# individual Redis containers; in K8s the pod is managed by a StatefulSet).
+source "$(dirname "$0")/helpers.sh"
+
+header "TEST 10 — AOF Persistence: Data Survives Redis Master Crash"
+
+seed_data
+
+# ── Stock: create an item and record its stock level ─────────────────────────
+
+ITEM_ID=$(json_field "$(post_body /stock/item/create/50)" "item_id")
+curl -s -X POST "$BASE_URL/stock/add/$ITEM_ID/42" > /dev/null
+STOCK_BEFORE=$(json_field "$(get_body /stock/find/$ITEM_ID)" "stock")
+assert_eq "Stock written before crash" "42" "$STOCK_BEFORE"
+
+# ── Payment: create a user with a known credit balance ───────────────────────
+
+USER_ID=$(json_field "$(post_body /payment/create_user)" "user_id")
+curl -s -X POST "$BASE_URL/payment/add_funds/$USER_ID/333" > /dev/null
+CREDIT_BEFORE=$(json_field "$(get_body /payment/find_user/$USER_ID)" "credit")
+assert_eq "Credit written before crash" "333" "$CREDIT_BEFORE"
+
+# ── Order: create an order and record its status ─────────────────────────────
+
+ORDER_ID=$(json_field "$(post_body /orders/create/$USER_ID)" "order_id")
+curl -s -X POST "$BASE_URL/orders/addItem/$ORDER_ID/$ITEM_ID/1" > /dev/null
+STATUS_BEFORE=$(json_field "$(get_body /orders/find/$ORDER_ID)" "status")
+assert_eq "Order written before crash" "pending" "$STATUS_BEFORE"
+
+# ── Crash and restore all Redis masters ──────────────────────────────────────
+
+redis_crash
+redis_restore
+
+yellow "Waiting for all services to reconnect to Redis..."
+for i in $(seq 1 20); do
+  stock_ok=$(json_field "$(get_body "/stock/find/$ITEM_ID")"        "stock")
+  credit_ok=$(json_field "$(get_body "/payment/find_user/$USER_ID")" "credit")
+  order_ok=$(json_field "$(get_body "/orders/find/$ORDER_ID")"       "status")
+  if [ -n "$stock_ok" ] && [ -n "$credit_ok" ] && [ -n "$order_ok" ]; then
+    green "All services reconnected to Redis"
+    break
+  fi
+  [ "$i" -eq 20 ] && red "Services did not reconnect in time" && exit 1
+  sleep 2
+done
+
+# ── Verify all data survived ─────────────────────────────────────────────────
+
+STOCK_AFTER=$(json_field "$(get_body /stock/find/$ITEM_ID)" "stock")
+assert_eq "Stock survived Redis master crash (AOF)" "$STOCK_BEFORE" "$STOCK_AFTER"
+
+CREDIT_AFTER=$(json_field "$(get_body /payment/find_user/$USER_ID)" "credit")
+assert_eq "Credit survived Redis master crash (AOF)" "$CREDIT_BEFORE" "$CREDIT_AFTER"
+
+STATUS_AFTER=$(json_field "$(get_body /orders/find/$ORDER_ID)" "status")
+assert_eq "Order survived Redis master crash (AOF)" "$STATUS_BEFORE" "$STATUS_AFTER"
+
+summary

--- a/test-scripts/helpers.sh
+++ b/test-scripts/helpers.sh
@@ -111,15 +111,15 @@ create_order_with_item() {
 
 # Maps a docker-compose service name to a Kubernetes resource:
 #   app services  → component label (used by Deployments)
-#   redis masters → StatefulSet pod name
+#   redis masters → StatefulSet pod name (one StatefulSet per Helm release)
 _kube_resource() {
   case "$1" in
-    *order-redis*)   echo "pod/redis-master-0"          ;;  # shared Redis in K8s
-    *stock-redis*)   echo "pod/redis-master-0"          ;;
-    *payment-redis*) echo "pod/redis-master-0"          ;;
-    *order*)         echo "label:component=order"       ;;
-    *stock*)         echo "label:component=stock"       ;;
-    *payment*)       echo "label:component=payment"     ;;
+    *order-redis*)   echo "pod/order-redis-master-0"   ;;
+    *stock-redis*)   echo "pod/stock-redis-master-0"   ;;
+    *payment-redis*) echo "pod/payment-redis-master-0" ;;
+    *order*)         echo "label:component=order"      ;;
+    *stock*)         echo "label:component=stock"      ;;
+    *payment*)       echo "label:component=payment"    ;;
   esac
 }
 
@@ -166,7 +166,7 @@ service_start() {
 
 # Crash ALL Redis masters (simulates a full data-store outage / power loss).
 # docker: stops all three per-service masters
-# kube:   deletes the single shared redis-master-0 pod (StatefulSet recreates it)
+# kube:   deletes the master-0 pod of each bitnami StatefulSet (each is recreated automatically)
 redis_crash() {
   yellow "Crashing Redis masters..."
   if [ "$DEPLOY_MODE" = "kube" ]; then
@@ -211,12 +211,8 @@ services:
       CHECKOUT_MODE: "${mode}"
 YAML
     docker compose stop order-service-1 order-service-2 > /dev/null 2>&1
-    if [ "$mode" = "saga" ]; then
-      docker compose up -d --no-deps order-service-1 order-service-2 > /dev/null 2>&1
-    else
-      docker compose -f docker-compose.yml -f "$override" \
-        up -d --no-deps order-service-1 order-service-2 > /dev/null 2>&1
-    fi
+    docker compose -f docker-compose.yml -f "$override" \
+      up -d --no-deps order-service-1 order-service-2 > /dev/null 2>&1
     rm -f "$override"
     sleep 4  # let gunicorn workers start and run 2PC recovery
   fi

--- a/test-scripts/helpers.sh
+++ b/test-scripts/helpers.sh
@@ -109,25 +109,34 @@ create_order_with_item() {
 # Runtime helpers — work in both DEPLOY_MODE=docker and DEPLOY_MODE=kube
 # ---------------------------------------------------------------------------
 
-# Maps a docker-compose service name (e.g. "order-service-1") to the
-# Kubernetes component label (e.g. "order").
-_kube_component() {
+# Maps a docker-compose service name to a Kubernetes resource:
+#   app services  → component label (used by Deployments)
+#   redis masters → StatefulSet pod name
+_kube_resource() {
   case "$1" in
-    *order*)   echo "order"   ;;
-    *stock*)   echo "stock"   ;;
-    *payment*) echo "payment" ;;
+    *order-redis*)   echo "pod/redis-master-0"          ;;  # shared Redis in K8s
+    *stock-redis*)   echo "pod/redis-master-0"          ;;
+    *payment-redis*) echo "pod/redis-master-0"          ;;
+    *order*)         echo "label:component=order"       ;;
+    *stock*)         echo "label:component=stock"       ;;
+    *payment*)       echo "label:component=payment"     ;;
   esac
 }
 
 # Kill one replica of a service.
 # docker: docker compose stop <name>
-# kube:   delete one pod selected by component label (K8s recreates it)
+# kube:   delete the pod (K8s / StatefulSet recreates it automatically)
 service_stop() {
   local svc="$1"
   if [ "$DEPLOY_MODE" = "kube" ]; then
-    local component pod
-    component=$(_kube_component "$svc")
-    pod=$(kubectl get pod -l "component=$component" -o name | head -1)
+    local resource pod
+    resource=$(_kube_resource "$svc")
+    if [[ "$resource" == pod/* ]]; then
+      pod="$resource"
+    else
+      local label="${resource#label:}"
+      pod=$(kubectl get pod -l "$label" -o name | head -1)
+    fi
     yellow "Deleting $pod..."
     kubectl delete "$pod" --grace-period=0 --wait=false > /dev/null 2>&1
   else
@@ -137,15 +146,47 @@ service_stop() {
 
 # Restore a service replica.
 # docker: docker compose start <name>
-# kube:   wait for the deployment to reach full readiness (pod is auto-recreated)
+# kube:   wait for the pod/deployment to reach full readiness
 service_start() {
   local svc="$1"
   if [ "$DEPLOY_MODE" = "kube" ]; then
-    local component
-    component=$(_kube_component "$svc")
-    kubectl rollout status "deployment/${component}-deployment" --timeout=60s > /dev/null 2>&1
+    local resource
+    resource=$(_kube_resource "$svc")
+    if [[ "$resource" == pod/* ]]; then
+      kubectl wait "${resource}" --for=condition=Ready --timeout=60s > /dev/null 2>&1
+    else
+      local label="${resource#label:}"
+      local component="${label#component=}"
+      kubectl rollout status "deployment/${component}-deployment" --timeout=60s > /dev/null 2>&1
+    fi
   else
     docker compose start "$svc" > /dev/null 2>&1
+  fi
+}
+
+# Crash ALL Redis masters (simulates a full data-store outage / power loss).
+# docker: stops all three per-service masters
+# kube:   deletes the single shared redis-master-0 pod (StatefulSet recreates it)
+redis_crash() {
+  yellow "Crashing Redis masters..."
+  if [ "$DEPLOY_MODE" = "kube" ]; then
+    kubectl delete pod/order-redis-master-0 pod/stock-redis-master-0 pod/payment-redis-master-0 \
+      --grace-period=0 --wait=false > /dev/null 2>&1
+  else
+    docker compose stop order-redis-master stock-redis-master payment-redis-master > /dev/null 2>&1
+  fi
+}
+
+# Restart ALL Redis masters and wait until they are ready (AOF replay complete).
+# docker: starts all three masters
+# kube:   waits for all three StatefulSet pods to become Ready again
+redis_restore() {
+  yellow "Restarting Redis masters (AOF replay on startup)..."
+  if [ "$DEPLOY_MODE" = "kube" ]; then
+    kubectl wait pod/order-redis-master-0 pod/stock-redis-master-0 pod/payment-redis-master-0 \
+      --for=condition=Ready --timeout=60s > /dev/null 2>&1
+  else
+    docker compose start order-redis-master stock-redis-master payment-redis-master > /dev/null 2>&1
   fi
 }
 
@@ -157,6 +198,7 @@ set_checkout_mode() {
   if [ "$DEPLOY_MODE" = "kube" ]; then
     kubectl set env deployment/order-deployment CHECKOUT_MODE="$mode" > /dev/null 2>&1
     kubectl rollout status deployment/order-deployment --timeout=60s > /dev/null 2>&1
+    sleep 4  # allow gunicorn workers to warm up Redis connections and run 2PC recovery
   else
     local override="/tmp/checkout_mode_override_$$.yml"
     cat > "$override" <<YAML

--- a/test-scripts/helpers.sh
+++ b/test-scripts/helpers.sh
@@ -2,6 +2,7 @@
 # Shared helpers for all test scripts
 
 BASE_URL="${BASE_URL:-http://localhost:8000}"
+DEPLOY_MODE="${DEPLOY_MODE:-docker}"   # "docker" or "kube"
 PASS=0
 FAIL=0
 
@@ -102,4 +103,79 @@ create_order_with_item() {
   oid=$(json_field "$body" "order_id")
   curl -s -X POST "$BASE_URL/orders/addItem/$oid/$item_id/$qty" > /dev/null
   echo "$oid"
+}
+
+# ---------------------------------------------------------------------------
+# Runtime helpers — work in both DEPLOY_MODE=docker and DEPLOY_MODE=kube
+# ---------------------------------------------------------------------------
+
+# Maps a docker-compose service name (e.g. "order-service-1") to the
+# Kubernetes component label (e.g. "order").
+_kube_component() {
+  case "$1" in
+    *order*)   echo "order"   ;;
+    *stock*)   echo "stock"   ;;
+    *payment*) echo "payment" ;;
+  esac
+}
+
+# Kill one replica of a service.
+# docker: docker compose stop <name>
+# kube:   delete one pod selected by component label (K8s recreates it)
+service_stop() {
+  local svc="$1"
+  if [ "$DEPLOY_MODE" = "kube" ]; then
+    local component pod
+    component=$(_kube_component "$svc")
+    pod=$(kubectl get pod -l "component=$component" -o name | head -1)
+    yellow "Deleting $pod..."
+    kubectl delete "$pod" --grace-period=0 --wait=false > /dev/null 2>&1
+  else
+    docker compose stop "$svc" > /dev/null 2>&1
+  fi
+}
+
+# Restore a service replica.
+# docker: docker compose start <name>
+# kube:   wait for the deployment to reach full readiness (pod is auto-recreated)
+service_start() {
+  local svc="$1"
+  if [ "$DEPLOY_MODE" = "kube" ]; then
+    local component
+    component=$(_kube_component "$svc")
+    kubectl rollout status "deployment/${component}-deployment" --timeout=60s > /dev/null 2>&1
+  else
+    docker compose start "$svc" > /dev/null 2>&1
+  fi
+}
+
+# Switch CHECKOUT_MODE on the order service.
+# docker: rewrites the service via a compose override file
+# kube:   kubectl set env + waits for rolling update to complete
+set_checkout_mode() {
+  local mode="$1"
+  if [ "$DEPLOY_MODE" = "kube" ]; then
+    kubectl set env deployment/order-deployment CHECKOUT_MODE="$mode" > /dev/null 2>&1
+    kubectl rollout status deployment/order-deployment --timeout=60s > /dev/null 2>&1
+  else
+    local override="/tmp/checkout_mode_override_$$.yml"
+    cat > "$override" <<YAML
+services:
+  order-service-1:
+    environment:
+      CHECKOUT_MODE: "${mode}"
+  order-service-2:
+    environment:
+      CHECKOUT_MODE: "${mode}"
+YAML
+    docker compose stop order-service-1 order-service-2 > /dev/null 2>&1
+    if [ "$mode" = "saga" ]; then
+      docker compose up -d --no-deps order-service-1 order-service-2 > /dev/null 2>&1
+    else
+      docker compose -f docker-compose.yml -f "$override" \
+        up -d --no-deps order-service-1 order-service-2 > /dev/null 2>&1
+    fi
+    rm -f "$override"
+    sleep 4  # let gunicorn workers start and run 2PC recovery
+  fi
 }

--- a/test-scripts/run_all.sh
+++ b/test-scripts/run_all.sh
@@ -74,6 +74,7 @@ run_test "$SCRIPT_DIR/09_2pc_protocol.sh"
 # Fault tolerance tests (stop/start containers — slower)
 if [ "${SKIP_FAULT_TESTS:-0}" != "1" ]; then
   run_test "$SCRIPT_DIR/05_fault_app_replica.sh"
+  run_test "$SCRIPT_DIR/10_redis_aof_persistence.sh"
   # run_test "$SCRIPT_DIR/06_fault_redis_master.sh"
 else
   echo ""


### PR DESCRIPTION
- Added kube infra yaml files
- updated test-scripts to work with kube too, added a DEPLOY_MODE variable that can be "docker" or "kube" and depending on it it will use different commands for stopping/starting a service and switching CHECKOUT_MODE
- Updated deploy-charts scripts
- Added instruction on how to deploy the kube infra and test it using minikube