### PR TITLE
Added 3 different compose files

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ A fault-tolerant, distributed e-commerce backend built with Flask microservices,
               └─────────────────────────┘
 ```
 
-The system is composed of three logical services (Order, Stock, Payment). Each service runs as **2 application replicas** behind a shared Nginx upstream pool. For data persistence and high availability, each service has its own isolated **Redis master + replica + Sentinel** cluster. The complete stack totals 19 containers (16 original + 3 Sentinels).
+The system is composed of three logical services (Order, Stock, Payment). Each service runs as one or more application replicas behind a shared Nginx upstream pool — the number of replicas depends on the chosen compose file (1 / 4 / 8 for small / medium / large). For data persistence and high availability, each service has its own isolated **Redis master + replica + Sentinel** cluster.
 
 ### Redis Architecture: State vs. Messaging
 
@@ -108,21 +108,35 @@ All state mutations use Redis `WATCH/MULTI/EXEC` optimistic locking with up to 1
 
 ## Getting Started
 
-### Docker Compose (Local Development)
+### Docker Compose
+
+Three compose files are provided targeting different CPU budgets. All expose the gateway on `http://localhost:8000`.
 
 **Prerequisites:** Docker ≥ 24, Docker Compose v2.
 
-1.  **Start the stack:**
-    ```bash
-    docker compose down -v          # wipe old volumes (clean slate)
-    docker compose up --build       # build images and start all 19 containers
-    ```
-    The gateway is available at `http://localhost:8000` once all services report healthy (~10–15 seconds).
+#### Small — single instance (~5 CPUs)
+One replica and one gunicorn worker per service.
 
-2.  **Run tests:**
-    ```bash
-    bash test-scripts/run_all.sh
-    ```
+```bash
+docker compose -f docker-compose-small.yml down -v
+docker compose -f docker-compose-small.yml up --build
+```
+
+#### Medium — ~50 CPUs
+Four replicas per service, each capped at 3.8 CPUs (total hard limit: 49.8 CPUs).
+
+```bash
+docker compose -f docker-compose-medium.yml down -v
+docker compose -f docker-compose-medium.yml up --build
+```
+
+#### Large — ~90 CPUs
+Eight replicas per service, each capped at 3.4 CPUs (total hard limit: 89.4 CPUs). Designed for 96-core machine, leaving ~6 CPUs for locust clients.
+
+```bash
+docker compose -f docker-compose-large.yml down -v
+docker compose -f docker-compose-large.yml up --build
+```
 
 ### Kubernetes — minikube (Local)
 

--- a/benchmark/urls.json
+++ b/benchmark/urls.json
@@ -1,5 +1,5 @@
 {
-  "ORDER_URL": "http://localhost:8080",
-  "PAYMENT_URL": "http://localhost:8080",
-  "STOCK_URL": "http://localhost:8080"
+  "ORDER_URL": "http://localhost:8000",
+  "PAYMENT_URL": "http://localhost:8000",
+  "STOCK_URL": "http://localhost:8000"
 }

--- a/docker-compose-large.yml
+++ b/docker-compose-large.yml
@@ -1,0 +1,420 @@
+## Large cluster: exactly 90 CPUs total (hard limits sum, leaves 6 for locust on 96-core machine).
+##
+## CPU accounting (hard limits, exact):
+##   mq-redis:                        1.0
+##   gateway (nginx):                 2.0
+##   order-service  ×8 (8 workers):   27.2  (8 replicas × 3.4 CPU limit)
+##   stock-service  ×8 (8 workers):   27.2
+##   payment-service×8 (8 workers):   27.2
+##   3× redis masters:                3.0   (1.0 each)
+##   3× redis replicas:               1.5   (0.5 each)
+##   3× redis sentinels:              0.3   (0.1 each)
+##   ─────────────────────────────────
+##   Total = 81.6 + 7.8 = 89.4 ≈ 90 CPUs
+##
+## Note: deploy.resources limits cap per-container usage. Under real load the
+## gunicorn processes will saturate their CPUs; the limits prevent any one
+## container from starving others.
+
+services:
+  # ── MESSAGE QUEUE BROKER ──────────────────────────────────────────────────
+  mq-redis:
+    image: redis:7.2-bookworm
+    command: ["redis-server", "--requirepass", "redis", "--maxmemory", "1gb",
+              "--hz", "20", "--dynamic-hz", "yes"]
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1280M
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "redis", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  # ── GATEWAY ───────────────────────────────────────────────────────────────
+  gateway:
+    image: nginx:1.25-bookworm
+    volumes:
+      - ./gateway_nginx_large.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "8000:80"
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 512M
+    depends_on:
+      - order-service-1
+      - order-service-2
+      - order-service-3
+      - order-service-4
+      - order-service-5
+      - order-service-6
+      - order-service-7
+      - order-service-8
+      - stock-service-1
+      - stock-service-2
+      - stock-service-3
+      - stock-service-4
+      - stock-service-5
+      - stock-service-6
+      - stock-service-7
+      - stock-service-8
+      - payment-service-1
+      - payment-service-2
+      - payment-service-3
+      - payment-service-4
+      - payment-service-5
+      - payment-service-6
+      - payment-service-7
+      - payment-service-8
+    restart: unless-stopped
+
+  # ── ORDER SERVICE (8 replicas × 8 workers) ───────────────────────────────
+  order-service-1: &order-service
+    build: ./order
+    image: order:latest
+    environment: &order-env
+      - MQ_REDIS_HOST=mq-redis
+      - MQ_REDIS_PORT=6379
+      - MQ_REDIS_PASSWORD=redis
+      - MQ_REDIS_DB=0
+      - GATEWAY_URL=http://gateway:80
+      - CHECKOUT_MODE=saga
+      - REDIS_HOST=order-redis-master
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=redis
+      - REDIS_DB=0
+      - REDIS_SENTINEL_HOSTS=order-redis-sentinel:26379
+      - REDIS_MASTER_NAME=order-master
+    command: gunicorn -b 0.0.0.0:5000 -w 8 --timeout 30 --log-level=info app:app
+    deploy:
+      resources:
+        limits:
+          cpus: "3.4"
+          memory: 512M
+    depends_on:
+      mq-redis:
+        condition: service_healthy
+      order-redis-sentinel:
+        condition: service_healthy
+    restart: unless-stopped
+
+  order-service-2:
+    <<: *order-service
+    environment: *order-env
+  order-service-3:
+    <<: *order-service
+    environment: *order-env
+  order-service-4:
+    <<: *order-service
+    environment: *order-env
+  order-service-5:
+    <<: *order-service
+    environment: *order-env
+  order-service-6:
+    <<: *order-service
+    environment: *order-env
+  order-service-7:
+    <<: *order-service
+    environment: *order-env
+  order-service-8:
+    <<: *order-service
+    environment: *order-env
+
+  order-redis-master:
+    image: redis:7.2-bookworm
+    command: ["redis-server", "--requirepass", "redis", "--masterauth", "redis",
+              "--maxmemory", "2gb", "--appendonly", "yes", "--appendfsync", "everysec",
+              "--hz", "20", "--dynamic-hz", "yes"]
+    volumes:
+      - order-master-data:/data
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 2560M
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "redis", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  order-redis-replica:
+    image: redis:7.2-bookworm
+    command: ["redis-server", "--requirepass", "redis", "--replicaof", "order-redis-master", "6379",
+              "--masterauth", "redis", "--maxmemory", "2gb", "--appendonly", "yes"]
+    volumes:
+      - order-replica-data:/data
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 2560M
+    depends_on:
+      order-redis-master:
+        condition: service_healthy
+    restart: unless-stopped
+
+  order-redis-sentinel:
+    image: redis:7.2-bookworm
+    command: >
+      sh -c "
+        echo 'sentinel resolve-hostnames yes' > /tmp/sentinel.conf &&
+        echo 'sentinel monitor order-master order-redis-master 6379 1' >> /tmp/sentinel.conf &&
+        echo 'sentinel auth-pass order-master redis' >> /tmp/sentinel.conf &&
+        echo 'sentinel down-after-milliseconds order-master 5000' >> /tmp/sentinel.conf &&
+        echo 'sentinel failover-timeout order-master 10000' >> /tmp/sentinel.conf &&
+        echo 'sentinel parallel-syncs order-master 1' >> /tmp/sentinel.conf &&
+        redis-server /tmp/sentinel.conf --sentinel --port 26379
+      "
+    deploy:
+      resources:
+        limits:
+          cpus: "0.1"
+          memory: 64M
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "26379", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+    depends_on:
+      order-redis-master:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # ── STOCK SERVICE (8 replicas × 8 workers) ───────────────────────────────
+  stock-service-1: &stock-service
+    build: ./stock
+    image: stock:latest
+    environment: &stock-env
+      - MQ_REDIS_HOST=mq-redis
+      - MQ_REDIS_PORT=6379
+      - MQ_REDIS_PASSWORD=redis
+      - MQ_REDIS_DB=0
+      - REDIS_HOST=stock-redis-master
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=redis
+      - REDIS_DB=0
+      - REDIS_SENTINEL_HOSTS=stock-redis-sentinel:26379
+      - REDIS_MASTER_NAME=stock-master
+    command: gunicorn -b 0.0.0.0:5000 -w 8 --timeout 30 --log-level=info app:app
+    deploy:
+      resources:
+        limits:
+          cpus: "3.4"
+          memory: 512M
+    depends_on:
+      mq-redis:
+        condition: service_healthy
+      stock-redis-sentinel:
+        condition: service_healthy
+    restart: unless-stopped
+
+  stock-service-2:
+    <<: *stock-service
+    environment: *stock-env
+  stock-service-3:
+    <<: *stock-service
+    environment: *stock-env
+  stock-service-4:
+    <<: *stock-service
+    environment: *stock-env
+  stock-service-5:
+    <<: *stock-service
+    environment: *stock-env
+  stock-service-6:
+    <<: *stock-service
+    environment: *stock-env
+  stock-service-7:
+    <<: *stock-service
+    environment: *stock-env
+  stock-service-8:
+    <<: *stock-service
+    environment: *stock-env
+
+  stock-redis-master:
+    image: redis:7.2-bookworm
+    command: ["redis-server", "--requirepass", "redis", "--masterauth", "redis",
+              "--maxmemory", "2gb", "--appendonly", "yes", "--appendfsync", "everysec",
+              "--hz", "20", "--dynamic-hz", "yes"]
+    volumes:
+      - stock-master-data:/data
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 2560M
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "redis", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  stock-redis-replica:
+    image: redis:7.2-bookworm
+    command: ["redis-server", "--requirepass", "redis", "--replicaof", "stock-redis-master", "6379",
+              "--masterauth", "redis", "--maxmemory", "2gb", "--appendonly", "yes"]
+    volumes:
+      - stock-replica-data:/data
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 2560M
+    depends_on:
+      stock-redis-master:
+        condition: service_healthy
+    restart: unless-stopped
+
+  stock-redis-sentinel:
+    image: redis:7.2-bookworm
+    command: >
+      sh -c "
+        echo 'sentinel resolve-hostnames yes' > /tmp/sentinel.conf &&
+        echo 'sentinel monitor stock-master stock-redis-master 6379 1' >> /tmp/sentinel.conf &&
+        echo 'sentinel auth-pass stock-master redis' >> /tmp/sentinel.conf &&
+        echo 'sentinel down-after-milliseconds stock-master 5000' >> /tmp/sentinel.conf &&
+        echo 'sentinel failover-timeout stock-master 10000' >> /tmp/sentinel.conf &&
+        echo 'sentinel parallel-syncs stock-master 1' >> /tmp/sentinel.conf &&
+        redis-server /tmp/sentinel.conf --sentinel --port 26379
+      "
+    deploy:
+      resources:
+        limits:
+          cpus: "0.1"
+          memory: 64M
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "26379", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+    depends_on:
+      stock-redis-master:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # ── PAYMENT SERVICE (8 replicas × 8 workers) ─────────────────────────────
+  payment-service-1: &payment-service
+    build: ./payment
+    image: user:latest
+    environment: &payment-env
+      - MQ_REDIS_HOST=mq-redis
+      - MQ_REDIS_PORT=6379
+      - MQ_REDIS_PASSWORD=redis
+      - MQ_REDIS_DB=0
+      - REDIS_HOST=payment-redis-master
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=redis
+      - REDIS_DB=0
+      - REDIS_SENTINEL_HOSTS=payment-redis-sentinel:26379
+      - REDIS_MASTER_NAME=payment-master
+    command: gunicorn -b 0.0.0.0:5000 -w 8 --timeout 30 --log-level=info app:app
+    deploy:
+      resources:
+        limits:
+          cpus: "3.4"
+          memory: 512M
+    depends_on:
+      mq-redis:
+        condition: service_healthy
+      payment-redis-sentinel:
+        condition: service_healthy
+    restart: unless-stopped
+
+  payment-service-2:
+    <<: *payment-service
+    environment: *payment-env
+  payment-service-3:
+    <<: *payment-service
+    environment: *payment-env
+  payment-service-4:
+    <<: *payment-service
+    environment: *payment-env
+  payment-service-5:
+    <<: *payment-service
+    environment: *payment-env
+  payment-service-6:
+    <<: *payment-service
+    environment: *payment-env
+  payment-service-7:
+    <<: *payment-service
+    environment: *payment-env
+  payment-service-8:
+    <<: *payment-service
+    environment: *payment-env
+
+  payment-redis-master:
+    image: redis:7.2-bookworm
+    command: ["redis-server", "--requirepass", "redis", "--masterauth", "redis",
+              "--maxmemory", "2gb", "--appendonly", "yes", "--appendfsync", "everysec",
+              "--hz", "20", "--dynamic-hz", "yes"]
+    volumes:
+      - payment-master-data:/data
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 2560M
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "redis", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  payment-redis-replica:
+    image: redis:7.2-bookworm
+    command: ["redis-server", "--requirepass", "redis", "--replicaof", "payment-redis-master", "6379",
+              "--masterauth", "redis", "--maxmemory", "2gb", "--appendonly", "yes"]
+    volumes:
+      - payment-replica-data:/data
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 2560M
+    depends_on:
+      payment-redis-master:
+        condition: service_healthy
+    restart: unless-stopped
+
+  payment-redis-sentinel:
+    image: redis:7.2-bookworm
+    command: >
+      sh -c "
+        echo 'sentinel resolve-hostnames yes' > /tmp/sentinel.conf &&
+        echo 'sentinel monitor payment-master payment-redis-master 6379 1' >> /tmp/sentinel.conf &&
+        echo 'sentinel auth-pass payment-master redis' >> /tmp/sentinel.conf &&
+        echo 'sentinel down-after-milliseconds payment-master 5000' >> /tmp/sentinel.conf &&
+        echo 'sentinel failover-timeout payment-master 10000' >> /tmp/sentinel.conf &&
+        echo 'sentinel parallel-syncs payment-master 1' >> /tmp/sentinel.conf &&
+        redis-server /tmp/sentinel.conf --sentinel --port 26379
+      "
+    deploy:
+      resources:
+        limits:
+          cpus: "0.1"
+          memory: 64M
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "26379", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+    depends_on:
+      payment-redis-master:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  order-master-data:
+  order-replica-data:
+  stock-master-data:
+  stock-replica-data:
+  payment-master-data:
+  payment-replica-data:

--- a/docker-compose-medium.yml
+++ b/docker-compose-medium.yml
@@ -1,0 +1,370 @@
+## Medium cluster: exactly 50 CPUs total (hard limits sum).
+##
+## CPU accounting (hard limits, exact):
+##   mq-redis:                        0.5
+##   gateway (nginx):                 1.0
+##   order-service  ×4 (8 workers):   15.2  (4 replicas × 3.8 CPU limit)
+##   stock-service  ×4 (8 workers):   15.2
+##   payment-service×4 (8 workers):   15.2
+##   3× redis masters:                1.5   (0.5 each)
+##   3× redis replicas:               0.9   (0.3 each)
+##   3× redis sentinels:              0.3   (0.1 each)
+##   ─────────────────────────────────
+##   Total = 45.6 + 4.2 = 49.8 ≈ 50 CPUs
+
+services:
+  # ── MESSAGE QUEUE BROKER ──────────────────────────────────────────────────
+  mq-redis:
+    image: redis:7.2-bookworm
+    command: ["redis-server", "--requirepass", "redis", "--maxmemory", "512mb"]
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 640M
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "redis", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  # ── GATEWAY ───────────────────────────────────────────────────────────────
+  gateway:
+    image: nginx:1.25-bookworm
+    volumes:
+      - ./gateway_nginx_medium.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "8000:80"
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 256M
+    depends_on:
+      - order-service-1
+      - order-service-2
+      - order-service-3
+      - order-service-4
+      - stock-service-1
+      - stock-service-2
+      - stock-service-3
+      - stock-service-4
+      - payment-service-1
+      - payment-service-2
+      - payment-service-3
+      - payment-service-4
+    restart: unless-stopped
+
+  # ── ORDER SERVICE (4 replicas × 8 workers, 3.8 CPU limit each) ──────────
+  order-service-1: &order-service
+    build: ./order
+    image: order:latest
+    environment: &order-env
+      - MQ_REDIS_HOST=mq-redis
+      - MQ_REDIS_PORT=6379
+      - MQ_REDIS_PASSWORD=redis
+      - MQ_REDIS_DB=0
+      - GATEWAY_URL=http://gateway:80
+      - CHECKOUT_MODE=saga
+      - REDIS_HOST=order-redis-master
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=redis
+      - REDIS_DB=0
+      - REDIS_SENTINEL_HOSTS=order-redis-sentinel:26379
+      - REDIS_MASTER_NAME=order-master
+    command: gunicorn -b 0.0.0.0:5000 -w 8 --timeout 30 --log-level=info app:app
+    deploy:
+      resources:
+        limits:
+          cpus: "3.8"
+          memory: 512M
+    depends_on:
+      mq-redis:
+        condition: service_healthy
+      order-redis-sentinel:
+        condition: service_healthy
+    restart: unless-stopped
+
+  order-service-2:
+    <<: *order-service
+    environment: *order-env
+
+  order-service-3:
+    <<: *order-service
+    environment: *order-env
+
+  order-service-4:
+    <<: *order-service
+    environment: *order-env
+
+  order-redis-master:
+    image: redis:7.2-bookworm
+    command: ["redis-server", "--requirepass", "redis", "--masterauth", "redis",
+              "--maxmemory", "1gb", "--appendonly", "yes", "--appendfsync", "everysec"]
+    volumes:
+      - order-master-data:/data
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 1280M
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "redis", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  order-redis-replica:
+    image: redis:7.2-bookworm
+    command: ["redis-server", "--requirepass", "redis", "--replicaof", "order-redis-master", "6379",
+              "--masterauth", "redis", "--maxmemory", "1gb", "--appendonly", "yes"]
+    volumes:
+      - order-replica-data:/data
+    deploy:
+      resources:
+        limits:
+          cpus: "0.3"
+          memory: 1280M
+    depends_on:
+      order-redis-master:
+        condition: service_healthy
+    restart: unless-stopped
+
+  order-redis-sentinel:
+    image: redis:7.2-bookworm
+    command: >
+      sh -c "
+        echo 'sentinel resolve-hostnames yes' > /tmp/sentinel.conf &&
+        echo 'sentinel monitor order-master order-redis-master 6379 1' >> /tmp/sentinel.conf &&
+        echo 'sentinel auth-pass order-master redis' >> /tmp/sentinel.conf &&
+        echo 'sentinel down-after-milliseconds order-master 5000' >> /tmp/sentinel.conf &&
+        echo 'sentinel failover-timeout order-master 10000' >> /tmp/sentinel.conf &&
+        echo 'sentinel parallel-syncs order-master 1' >> /tmp/sentinel.conf &&
+        redis-server /tmp/sentinel.conf --sentinel --port 26379
+      "
+    deploy:
+      resources:
+        limits:
+          cpus: "0.1"
+          memory: 64M
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "26379", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+    depends_on:
+      order-redis-master:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # ── STOCK SERVICE (4 replicas × 8 workers) ───────────────────────────────
+  stock-service-1: &stock-service
+    build: ./stock
+    image: stock:latest
+    environment: &stock-env
+      - MQ_REDIS_HOST=mq-redis
+      - MQ_REDIS_PORT=6379
+      - MQ_REDIS_PASSWORD=redis
+      - MQ_REDIS_DB=0
+      - REDIS_HOST=stock-redis-master
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=redis
+      - REDIS_DB=0
+      - REDIS_SENTINEL_HOSTS=stock-redis-sentinel:26379
+      - REDIS_MASTER_NAME=stock-master
+    command: gunicorn -b 0.0.0.0:5000 -w 8 --timeout 30 --log-level=info app:app
+    deploy:
+      resources:
+        limits:
+          cpus: "3.8"
+          memory: 512M
+    depends_on:
+      mq-redis:
+        condition: service_healthy
+      stock-redis-sentinel:
+        condition: service_healthy
+    restart: unless-stopped
+
+  stock-service-2:
+    <<: *stock-service
+    environment: *stock-env
+
+  stock-service-3:
+    <<: *stock-service
+    environment: *stock-env
+
+  stock-service-4:
+    <<: *stock-service
+    environment: *stock-env
+
+  stock-redis-master:
+    image: redis:7.2-bookworm
+    command: ["redis-server", "--requirepass", "redis", "--masterauth", "redis",
+              "--maxmemory", "1gb", "--appendonly", "yes", "--appendfsync", "everysec"]
+    volumes:
+      - stock-master-data:/data
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 1280M
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "redis", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  stock-redis-replica:
+    image: redis:7.2-bookworm
+    command: ["redis-server", "--requirepass", "redis", "--replicaof", "stock-redis-master", "6379",
+              "--masterauth", "redis", "--maxmemory", "1gb", "--appendonly", "yes"]
+    volumes:
+      - stock-replica-data:/data
+    deploy:
+      resources:
+        limits:
+          cpus: "0.3"
+          memory: 1280M
+    depends_on:
+      stock-redis-master:
+        condition: service_healthy
+    restart: unless-stopped
+
+  stock-redis-sentinel:
+    image: redis:7.2-bookworm
+    command: >
+      sh -c "
+        echo 'sentinel resolve-hostnames yes' > /tmp/sentinel.conf &&
+        echo 'sentinel monitor stock-master stock-redis-master 6379 1' >> /tmp/sentinel.conf &&
+        echo 'sentinel auth-pass stock-master redis' >> /tmp/sentinel.conf &&
+        echo 'sentinel down-after-milliseconds stock-master 5000' >> /tmp/sentinel.conf &&
+        echo 'sentinel failover-timeout stock-master 10000' >> /tmp/sentinel.conf &&
+        echo 'sentinel parallel-syncs stock-master 1' >> /tmp/sentinel.conf &&
+        redis-server /tmp/sentinel.conf --sentinel --port 26379
+      "
+    deploy:
+      resources:
+        limits:
+          cpus: "0.1"
+          memory: 64M
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "26379", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+    depends_on:
+      stock-redis-master:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # ── PAYMENT SERVICE (4 replicas × 8 workers) ─────────────────────────────
+  payment-service-1: &payment-service
+    build: ./payment
+    image: user:latest
+    environment: &payment-env
+      - MQ_REDIS_HOST=mq-redis
+      - MQ_REDIS_PORT=6379
+      - MQ_REDIS_PASSWORD=redis
+      - MQ_REDIS_DB=0
+      - REDIS_HOST=payment-redis-master
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=redis
+      - REDIS_DB=0
+      - REDIS_SENTINEL_HOSTS=payment-redis-sentinel:26379
+      - REDIS_MASTER_NAME=payment-master
+    command: gunicorn -b 0.0.0.0:5000 -w 8 --timeout 30 --log-level=info app:app
+    deploy:
+      resources:
+        limits:
+          cpus: "3.8"
+          memory: 512M
+    depends_on:
+      mq-redis:
+        condition: service_healthy
+      payment-redis-sentinel:
+        condition: service_healthy
+    restart: unless-stopped
+
+  payment-service-2:
+    <<: *payment-service
+    environment: *payment-env
+
+  payment-service-3:
+    <<: *payment-service
+    environment: *payment-env
+
+  payment-service-4:
+    <<: *payment-service
+    environment: *payment-env
+
+  payment-redis-master:
+    image: redis:7.2-bookworm
+    command: ["redis-server", "--requirepass", "redis", "--masterauth", "redis",
+              "--maxmemory", "1gb", "--appendonly", "yes", "--appendfsync", "everysec"]
+    volumes:
+      - payment-master-data:/data
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 1280M
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "redis", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  payment-redis-replica:
+    image: redis:7.2-bookworm
+    command: ["redis-server", "--requirepass", "redis", "--replicaof", "payment-redis-master", "6379",
+              "--masterauth", "redis", "--maxmemory", "1gb", "--appendonly", "yes"]
+    volumes:
+      - payment-replica-data:/data
+    deploy:
+      resources:
+        limits:
+          cpus: "0.3"
+          memory: 1280M
+    depends_on:
+      payment-redis-master:
+        condition: service_healthy
+    restart: unless-stopped
+
+  payment-redis-sentinel:
+    image: redis:7.2-bookworm
+    command: >
+      sh -c "
+        echo 'sentinel resolve-hostnames yes' > /tmp/sentinel.conf &&
+        echo 'sentinel monitor payment-master payment-redis-master 6379 1' >> /tmp/sentinel.conf &&
+        echo 'sentinel auth-pass payment-master redis' >> /tmp/sentinel.conf &&
+        echo 'sentinel down-after-milliseconds payment-master 5000' >> /tmp/sentinel.conf &&
+        echo 'sentinel failover-timeout payment-master 10000' >> /tmp/sentinel.conf &&
+        echo 'sentinel parallel-syncs payment-master 1' >> /tmp/sentinel.conf &&
+        redis-server /tmp/sentinel.conf --sentinel --port 26379
+      "
+    deploy:
+      resources:
+        limits:
+          cpus: "0.1"
+          memory: 64M
+    healthcheck:
+      test: ["CMD", "redis-cli", "-p", "26379", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 15
+    depends_on:
+      payment-redis-master:
+        condition: service_healthy
+    restart: unless-stopped
+
+volumes:
+  order-master-data:
+  order-replica-data:
+  stock-master-data:
+  stock-replica-data:
+  payment-master-data:
+  payment-replica-data:

--- a/docker-compose-small.yml
+++ b/docker-compose-small.yml
@@ -1,0 +1,149 @@
+## Single instance: 1 replica per service, 1 gunicorn worker each, 1 standalone Redis each.
+## Per the assignment: "single instance, with a single worker on each service and database/etc."
+## No replicas, no sentinels — one Redis container per service.
+##
+## CPU accounting (rough):
+##   mq-redis:            0.2
+##   gateway (nginx):     0.1
+##   order-service:       ~1 CPU
+##   stock-service:       ~1 CPU
+##   payment-service:     ~1 CPU
+##   order-redis:         0.2
+##   stock-redis:         0.2
+##   payment-redis:       0.2
+##   ─────────────────────────────────
+##   Total ≈ 4 CPUs
+
+services:
+  # ── MESSAGE QUEUE BROKER ──────────────────────────────────────────────────
+  mq-redis:
+    image: redis:7.2-bookworm
+    command: ["redis-server", "--requirepass", "redis", "--maxmemory", "256mb"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "redis", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  # ── GATEWAY ───────────────────────────────────────────────────────────────
+  gateway:
+    image: nginx:1.25-bookworm
+    volumes:
+      - ./gateway_nginx_small.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "8000:80"
+    depends_on:
+      - order-service
+      - stock-service
+      - payment-service
+    restart: unless-stopped
+
+  # ── ORDER SERVICE (1 replica, 1 worker) ──────────────────────────────────
+  order-service:
+    build: ./order
+    image: order:latest
+    environment:
+      - MQ_REDIS_HOST=mq-redis
+      - MQ_REDIS_PORT=6379
+      - MQ_REDIS_PASSWORD=redis
+      - MQ_REDIS_DB=0
+      - GATEWAY_URL=http://gateway:80
+      - CHECKOUT_MODE=saga
+      - REDIS_HOST=order-redis
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=redis
+      - REDIS_DB=0
+    command: gunicorn -b 0.0.0.0:5000 -w 1 --timeout 30 --log-level=info app:app
+    depends_on:
+      mq-redis:
+        condition: service_healthy
+      order-redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  order-redis:
+    image: redis:7.2-bookworm
+    command: ["redis-server", "--requirepass", "redis",
+              "--maxmemory", "512mb", "--appendonly", "yes", "--appendfsync", "everysec"]
+    volumes:
+      - order-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "redis", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  # ── STOCK SERVICE (1 replica, 1 worker) ──────────────────────────────────
+  stock-service:
+    build: ./stock
+    image: stock:latest
+    environment:
+      - MQ_REDIS_HOST=mq-redis
+      - MQ_REDIS_PORT=6379
+      - MQ_REDIS_PASSWORD=redis
+      - MQ_REDIS_DB=0
+      - REDIS_HOST=stock-redis
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=redis
+      - REDIS_DB=0
+    command: gunicorn -b 0.0.0.0:5000 -w 1 --timeout 30 --log-level=info app:app
+    depends_on:
+      mq-redis:
+        condition: service_healthy
+      stock-redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  stock-redis:
+    image: redis:7.2-bookworm
+    command: ["redis-server", "--requirepass", "redis",
+              "--maxmemory", "512mb", "--appendonly", "yes", "--appendfsync", "everysec"]
+    volumes:
+      - stock-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "redis", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+  # ── PAYMENT SERVICE (1 replica, 1 worker) ────────────────────────────────
+  payment-service:
+    build: ./payment
+    image: user:latest
+    environment:
+      - MQ_REDIS_HOST=mq-redis
+      - MQ_REDIS_PORT=6379
+      - MQ_REDIS_PASSWORD=redis
+      - MQ_REDIS_DB=0
+      - REDIS_HOST=payment-redis
+      - REDIS_PORT=6379
+      - REDIS_PASSWORD=redis
+      - REDIS_DB=0
+    command: gunicorn -b 0.0.0.0:5000 -w 1 --timeout 30 --log-level=info app:app
+    depends_on:
+      mq-redis:
+        condition: service_healthy
+      payment-redis:
+        condition: service_healthy
+    restart: unless-stopped
+
+  payment-redis:
+    image: redis:7.2-bookworm
+    command: ["redis-server", "--requirepass", "redis",
+              "--maxmemory", "512mb", "--appendonly", "yes", "--appendfsync", "everysec"]
+    volumes:
+      - payment-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "-a", "redis", "ping"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+    restart: unless-stopped
+
+volumes:
+  order-data:
+  stock-data:
+  payment-data:

--- a/gateway_nginx_large.conf
+++ b/gateway_nginx_large.conf
@@ -1,0 +1,68 @@
+worker_processes 4;
+
+events { worker_connections 8192; }
+
+http {
+    upstream order-app {
+        server order-service-1:5000 max_fails=1 fail_timeout=5s;
+        server order-service-2:5000 max_fails=1 fail_timeout=5s;
+        server order-service-3:5000 max_fails=1 fail_timeout=5s;
+        server order-service-4:5000 max_fails=1 fail_timeout=5s;
+        server order-service-5:5000 max_fails=1 fail_timeout=5s;
+        server order-service-6:5000 max_fails=1 fail_timeout=5s;
+        server order-service-7:5000 max_fails=1 fail_timeout=5s;
+        server order-service-8:5000 max_fails=1 fail_timeout=5s;
+        keepalive 128;
+    }
+    upstream payment-app {
+        server payment-service-1:5000 max_fails=1 fail_timeout=5s;
+        server payment-service-2:5000 max_fails=1 fail_timeout=5s;
+        server payment-service-3:5000 max_fails=1 fail_timeout=5s;
+        server payment-service-4:5000 max_fails=1 fail_timeout=5s;
+        server payment-service-5:5000 max_fails=1 fail_timeout=5s;
+        server payment-service-6:5000 max_fails=1 fail_timeout=5s;
+        server payment-service-7:5000 max_fails=1 fail_timeout=5s;
+        server payment-service-8:5000 max_fails=1 fail_timeout=5s;
+        keepalive 128;
+    }
+    upstream stock-app {
+        server stock-service-1:5000 max_fails=1 fail_timeout=5s;
+        server stock-service-2:5000 max_fails=1 fail_timeout=5s;
+        server stock-service-3:5000 max_fails=1 fail_timeout=5s;
+        server stock-service-4:5000 max_fails=1 fail_timeout=5s;
+        server stock-service-5:5000 max_fails=1 fail_timeout=5s;
+        server stock-service-6:5000 max_fails=1 fail_timeout=5s;
+        server stock-service-7:5000 max_fails=1 fail_timeout=5s;
+        server stock-service-8:5000 max_fails=1 fail_timeout=5s;
+        keepalive 128;
+    }
+
+    server {
+        listen 80;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+
+        proxy_next_upstream error timeout http_500 http_502 http_503;
+        proxy_next_upstream_tries 8;
+        proxy_connect_timeout 2s;
+        proxy_read_timeout 30s;
+
+        location /orders/ {
+            proxy_pass http://order-app/;
+        }
+        location /payment/ {
+            proxy_pass http://payment-app/;
+        }
+        location /stock/ {
+            proxy_pass http://stock-app/;
+        }
+
+        access_log /var/log/nginx/server.access.log;
+    }
+
+    access_log /var/log/nginx/access.log;
+}

--- a/gateway_nginx_medium.conf
+++ b/gateway_nginx_medium.conf
@@ -1,0 +1,54 @@
+events { worker_connections 4096; }
+
+http {
+    upstream order-app {
+        server order-service-1:5000 max_fails=1 fail_timeout=5s;
+        server order-service-2:5000 max_fails=1 fail_timeout=5s;
+        server order-service-3:5000 max_fails=1 fail_timeout=5s;
+        server order-service-4:5000 max_fails=1 fail_timeout=5s;
+        keepalive 64;
+    }
+    upstream payment-app {
+        server payment-service-1:5000 max_fails=1 fail_timeout=5s;
+        server payment-service-2:5000 max_fails=1 fail_timeout=5s;
+        server payment-service-3:5000 max_fails=1 fail_timeout=5s;
+        server payment-service-4:5000 max_fails=1 fail_timeout=5s;
+        keepalive 64;
+    }
+    upstream stock-app {
+        server stock-service-1:5000 max_fails=1 fail_timeout=5s;
+        server stock-service-2:5000 max_fails=1 fail_timeout=5s;
+        server stock-service-3:5000 max_fails=1 fail_timeout=5s;
+        server stock-service-4:5000 max_fails=1 fail_timeout=5s;
+        keepalive 64;
+    }
+
+    server {
+        listen 80;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+
+        proxy_next_upstream error timeout http_500 http_502 http_503;
+        proxy_next_upstream_tries 4;
+        proxy_connect_timeout 2s;
+        proxy_read_timeout 30s;
+
+        location /orders/ {
+            proxy_pass http://order-app/;
+        }
+        location /payment/ {
+            proxy_pass http://payment-app/;
+        }
+        location /stock/ {
+            proxy_pass http://stock-app/;
+        }
+
+        access_log /var/log/nginx/server.access.log;
+    }
+
+    access_log /var/log/nginx/access.log;
+}

--- a/gateway_nginx_small.conf
+++ b/gateway_nginx_small.conf
@@ -1,0 +1,45 @@
+events { worker_connections 1024; }
+
+http {
+    upstream order-app {
+        server order-service:5000 max_fails=1 fail_timeout=5s;
+        keepalive 16;
+    }
+    upstream payment-app {
+        server payment-service:5000 max_fails=1 fail_timeout=5s;
+        keepalive 16;
+    }
+    upstream stock-app {
+        server stock-service:5000 max_fails=1 fail_timeout=5s;
+        keepalive 16;
+    }
+
+    server {
+        listen 80;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+
+        proxy_next_upstream error timeout http_500 http_502 http_503;
+        proxy_next_upstream_tries 1;
+        proxy_connect_timeout 2s;
+        proxy_read_timeout 30s;
+
+        location /orders/ {
+            proxy_pass http://order-app/;
+        }
+        location /payment/ {
+            proxy_pass http://payment-app/;
+        }
+        location /stock/ {
+            proxy_pass http://stock-app/;
+        }
+
+        access_log /var/log/nginx/server.access.log;
+    }
+
+    access_log /var/log/nginx/access.log;
+}


### PR DESCRIPTION
fixes #17

Small: uses one instance with a single worker for each service (no redist sentinel replicas)
```
## CPU accounting (rough):
##   mq-redis:            0.2
##   gateway (nginx):     0.1
##   order-service:       ~1 CPU
##   stock-service:       ~1 CPU
##   payment-service:     ~1 CPU
##   order-redis:         0.2
##   stock-redis:         0.2
##   payment-redis:       0.2
##   ─────────────────────────────────
##   Total ≈ 4 CPUs
```

Medium: 50 CPUs total limit - 4 replicas per service, 8 workers each. 1 reds master+1 replica+1 sentinel per service
```
## CPU accounting (hard limits, exact):
##   mq-redis:                        0.5
##   gateway (nginx):                 1.0
##   order-service  ×4 (8 workers):   15.2  (4 replicas × 3.8 CPU limit)
##   stock-service  ×4 (8 workers):   15.2
##   payment-service×4 (8 workers):   15.2
##   3× redis masters:                1.5   (0.5 each)
##   3× redis replicas:               0.9   (0.3 each)
##   3× redis sentinels:              0.3   (0.1 each)
##   ─────────────────────────────────
##   Total = 45.6 + 4.2 = 49.8 ≈ 50 CPUs
```

Large: 90 CPUs total limit - 8 replicas per service, 8 workers. 1 redis master + 1 replica + 1 sentinel per service
```
## CPU accounting (hard limits, exact):
##   mq-redis:                        1.0
##   gateway (nginx):                 2.0
##   order-service  ×8 (8 workers):   27.2  (8 replicas × 3.4 CPU limit)
##   stock-service  ×8 (8 workers):   27.2
##   payment-service×8 (8 workers):   27.2
##   3× redis masters:                3.0   (1.0 each)
##   3× redis replicas:               1.5   (0.5 each)
##   3× redis sentinels:              0.3   (0.1 each)
##   ─────────────────────────────────
##   Total = 81.6 + 7.8 = 89.4 ≈ 90 CPUs
```