### PR TITLE
Decouple WAL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 CLAUDE.md
 .vscode/*
+*/__pycache__/*

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A fault-tolerant, distributed e-commerce backend built with Flask microservices,
               └─────────────────────────┘
 ```
 
-The system is composed of three logical services (Order, Stock, Payment) and an **Orchestrator** that coordinates multi-service transactions. Each service runs as **2 application replicas** behind a shared Nginx upstream pool. For data persistence and high availability, each service — including the orchestrator — has its own isolated **Redis master + replica + Sentinel** cluster. The complete stack totals 22 containers.
+The system is composed of three logical services (Order, Stock, Payment) and an **Orchestrator** that coordinates multi-service transactions. Each service runs as **2 application replicas** behind a shared Nginx upstream pool. For data persistence and high availability, each service — including the orchestrator — has its own isolated **Redis master + replica + Sentinel** cluster. A shared **WAL Redis** cluster (master + replica + Sentinel) stores all Write-Ahead Log entries independently of every service's business data. The complete stack totals **22 containers**.
 
 ### Redis Architecture: State vs. Messaging
 
@@ -64,12 +64,12 @@ These connections are configured via separate environment variables to allow spl
 
 The **Orchestrator** is a standalone service (2 replicas) that executes multi-step transaction workflows on behalf of the Order service. When the Order service initiates a checkout, it submits a **batch** of tasks to the orchestrator via the `events:orchestrator` Redis Stream. The orchestrator:
 
-1.  **Persists the batch to a WAL** (`orch:pending` set + `orch:batch:{id}` key) in its own Sentinel-backed Redis cluster before processing.
+1.  **Persists the batch to a WAL** (`wal:orch:pending` set + `wal:orch:batch:{id}` key) in the shared `wal-redis` cluster before processing.
 2.  **Dispatches tasks** to participant streams (`events:stock`, `events:payment`) respecting dependency ordering.
 3.  **Collects replies** via temporary `BLPOP` keys and retries failed deliveries (configurable via `ORCH_MAX_RETRIES`).
 4.  **Pushes the final result** back to the Order service's `reply_to` key and cleans up the WAL.
 
-On startup, each orchestrator replica runs a **recovery sweep**: it scans `orch:pending`, acquires distributed locks to prevent duplicate processing, and re-drives any incomplete batches. This ensures crash recovery even if the orchestrator dies mid-transaction.
+On startup, each orchestrator replica runs a **recovery sweep**: it scans `wal:orch:pending` in `wal-redis`, acquires distributed locks (`wal:orch:lock:{batch_id}`) to prevent duplicate processing, and re-drives any incomplete batches. This ensures crash recovery even if the orchestrator dies mid-transaction.
 
 ## Service Interaction: RPC over Streams
 
@@ -101,8 +101,30 @@ A critical challenge in distributed systems is message reordering or retries. If
 *   When a rollback arrives for an unknown transaction, the service records a "Tombstone" (e.g., `TX_ROLLED_BACK`).
 *   If the original request arrives later, the service sees the Tombstone and ignores the request.
 
+### Decoupled Write-Ahead Log (WAL)
+
+Every WAL entry in the system lives in a **dedicated `wal-redis` cluster** that is completely separate from each service's business-data Redis. This is the core persistence guarantee:
+
+| What | Where stored | Key namespace |
+|------|-------------|---------------|
+| Saga in-flight orders | `wal-redis` | `wal:order:saga:pending` (Set) |
+| 2PC coordinator in-flight | `wal-redis` | `wal:order:2pc:pending` (Set) |
+| Saga tx-id per attempt | `wal-redis` | `wal:order:saga:tx:{order_id}` |
+| Stock 2PC state machine | `wal-redis` | `wal:stock:2pc:{order_id}` |
+| Payment 2PC state machine | `wal-redis` | `wal:payment:2pc:{order_id}:{user_id}` |
+| Orchestrator batch state | `wal-redis` | `wal:orch:batch:{batch_id}` (JSON) |
+| Orchestrator in-flight set | `wal-redis` | `wal:orch:pending` (Set) |
+| Orchestrator recovery locks | `wal-redis` | `wal:orch:lock:{batch_id}` (TTL key) |
+
+**Why this matters:** if `order-redis`, `stock-redis`, or `payment-redis` is wiped or corrupted, the WAL is untouched. On restart, the service reads its business data (which may be partially restored via AOF/replica) and reads the WAL from `wal-redis` to determine which transactions need to be committed or rolled back. The two stores are never written in the same pipeline or transaction.
+
+**Separation rule enforced in code:** every service has a `wal.py` module that opens an independent Redis connection to `wal-redis`. Business writes go to `db` (business Redis); WAL writes go to `wal` (WAL Redis). These are never mixed in the same `WATCH/MULTI/EXEC` pipeline.
+
+**`--appendfsync always`:** `wal-redis` is configured with `appendfsync always` (fsync on every write) rather than `everysec`. This guarantees zero WAL data loss even on a hard crash, at the cost of slightly higher latency on WAL writes.
+
 ### Background Recovery
-On startup, each `order-service` replica scans its WAL (`2pc:pending` or `saga:pending`). If it finds transactions that were in-flight during a crash, it deterministically re-drives them to completion (either committing or rolling back). Similarly, each **orchestrator** replica runs a recovery sweep on startup, scanning `orch:pending` and re-dispatching any incomplete task batches using distributed locks to prevent duplicate processing across replicas.
+
+On startup, each `order-service` replica scans its WAL (`wal:order:saga:pending` or `wal:order:2pc:pending`) in `wal-redis`. If it finds transactions that were in-flight during a crash, it deterministically re-drives them. Each **orchestrator** replica scans `wal:orch:pending` in the same `wal-redis`, acquires distributed locks (`wal:orch:lock:{batch_id}`) to prevent duplicate processing, and re-dispatches any incomplete batches. All participant services are idempotent, so re-driving a batch that was partially completed is safe.
 
 ### Application Replica Failure
 Nginx upstream pools are configured with `max_fails=1 fail_timeout=5s` and `proxy_next_upstream error timeout http_500 http_502 http_503`. When one replica crashes, Nginx automatically retries the request on the healthy one. All containers use `restart: unless-stopped`.
@@ -179,14 +201,19 @@ Configuration is managed via environment variables in `docker-compose.yml` or K8
 | `REDIS_PASSWORD`| all | Redis auth password | `redis` |
 | `REDIS_SENTINEL_HOSTS` | all | Comma-separated `host:port` list of Sentinel nodes | *(optional)* |
 | `REDIS_MASTER_NAME` | all | Sentinel master set name | `mymaster` |
+| `WAL_REDIS_HOST` | order, stock, payment | Decoupled WAL Redis hostname (fallback) | `wal-redis-master` |
+| `WAL_REDIS_PORT` | order, stock, payment | WAL Redis port | `6379` |
+| `WAL_REDIS_PASSWORD` | order, stock, payment | WAL Redis auth password | `redis` |
+| `WAL_REDIS_DB` | order, stock, payment | WAL Redis database index | `0` |
+| `WAL_SENTINEL_HOSTS` | order, stock, payment | WAL Sentinel `host:port` nodes | `wal-redis-sentinel:26379` |
+| `WAL_MASTER_NAME` | order, stock, payment | WAL Sentinel master set name | `wal-master` |
 | `MQ_REDIS_HOST` | all | Host for the MQ connection (Redis Streams) | *(required)* |
 | `MQ_REDIS_PORT` | all | Port for the MQ connection | `6379` |
 | `MQ_REDIS_PASSWORD`| all | Password for the MQ connection | `redis` |
 | `MQ_REDIS_DB` | all | DB index for the MQ connection | `0` |
-| `ORCH_SENTINEL_HOSTS` | orchestrator | Sentinel `host:port` for orchestrator WAL Redis | *(optional)* |
-| `ORCH_MASTER_NAME` | orchestrator | Sentinel master set name for orchestrator Redis | `orch-master` |
-| `ORCH_REDIS_HOST` | orchestrator | Direct Redis host (fallback when Sentinel is not used) | *(optional)* |
-| `ORCH_REDIS_PASSWORD` | orchestrator | Orchestrator Redis auth password | `redis` |
+| `ORCH_MAX_RETRIES` | orchestrator | Max task dispatch retries per attempt | `3` |
+| `ORCH_TASK_TIMEOUT_S` | orchestrator | Per-attempt reply timeout in seconds | `5` |
+| `ORCH_CONSUMER_NAME` | orchestrator | Unique consumer name per replica | `orchestrator-1` |
 | `ORCH_MAX_RETRIES` | orchestrator | Max retry attempts per task delivery | `3` |
 | `ORCH_TASK_TIMEOUT_S` | orchestrator | Timeout (seconds) waiting for a task reply | `5` |
 
@@ -207,6 +234,7 @@ Configuration is managed via environment variables in `docker-compose.yml` or K8
 | `11_native_mq_2pc.sh` | Tests 2PC participant protocol directly over MQ (prepare, commit, abort). |
 | `12_orchestrator.sh` | Orchestrator integration tests: saga/2PC flows, concurrency, pause/resume, WAL recovery. |
 | `13_microservices_pytest.sh` | Python integration tests for stock, payment, and order service correctness. |
+| `14_wal_decoupled.sh` | Verifies WAL keys live only in `wal-redis` for all services and orchestrator; confirms WAL survives killing business-data Redis and both orchestrator containers. |
 
 ## Technology Stack
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
   wal-redis-replica:
     image: redis:7.2-bookworm
     command: ["redis-server", "--requirepass", "redis", "--replicaof", "wal-redis-master", "6379",
-              "--masterauth", "redis", "--maxmemory", "256mb", "--appendonly", "yes", "--appendfsync", "always"]
+              "--masterauth", "redis", "--maxmemory", "512mb", "--appendonly", "yes", "--appendfsync", "always"]
     volumes:
       - wal-replica-data:/data
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,16 @@
 services:
-  # ORCHESTRATOR WAL STORE
-  orch-redis-master:
+  # ── SHARED WAL STORE ────────────────────────────────────────────────────────
+  # A dedicated Redis cluster whose sole job is to store Write-Ahead Log
+  # entries for order, stock, and payment services. Kept intentionally separate
+  # from every service's business-data Redis so WAL entries survive even if a
+  # service's own data store fails or is wiped.
+  # --appendfsync always guarantees every WAL append is fsynced to disk.
+  wal-redis-master:
     image: redis:7.2-bookworm
     command: ["redis-server", "--requirepass", "redis", "--masterauth", "redis",
-              "--maxmemory", "512mb", "--appendonly", "yes", "--appendfsync", "everysec"]
+              "--maxmemory", "512mb", "--appendonly", "yes", "--appendfsync", "always"]
     volumes:
-      - orch-master-data:/data
+      - wal-master-data:/data
     healthcheck:
       test: ["CMD", "redis-cli", "-a", "redis", "ping"]
       interval: 2s
@@ -13,27 +18,27 @@ services:
       retries: 10
     restart: unless-stopped
 
-  orch-redis-replica:
+  wal-redis-replica:
     image: redis:7.2-bookworm
-    command: ["redis-server", "--requirepass", "redis", "--replicaof", "orch-redis-master", "6379",
-              "--masterauth", "redis", "--maxmemory", "512mb", "--appendonly", "yes"]
+    command: ["redis-server", "--requirepass", "redis", "--replicaof", "wal-redis-master", "6379",
+              "--masterauth", "redis", "--maxmemory", "256mb", "--appendonly", "yes", "--appendfsync", "always"]
     volumes:
-      - orch-replica-data:/data
+      - wal-replica-data:/data
     depends_on:
-      orch-redis-master:
+      wal-redis-master:
         condition: service_healthy
     restart: unless-stopped
 
-  orch-redis-sentinel:
+  wal-redis-sentinel:
     image: redis:7.2-bookworm
     command: >
       sh -c "
         echo 'sentinel resolve-hostnames yes' > /tmp/sentinel.conf &&
-        echo 'sentinel monitor orch-master orch-redis-master 6379 1' >> /tmp/sentinel.conf &&
-        echo 'sentinel auth-pass orch-master redis' >> /tmp/sentinel.conf &&
-        echo 'sentinel down-after-milliseconds orch-master 5000' >> /tmp/sentinel.conf &&
-        echo 'sentinel failover-timeout orch-master 10000' >> /tmp/sentinel.conf &&
-        echo 'sentinel parallel-syncs orch-master 1' >> /tmp/sentinel.conf &&
+        echo 'sentinel monitor wal-master wal-redis-master 6379 1' >> /tmp/sentinel.conf &&
+        echo 'sentinel auth-pass wal-master redis' >> /tmp/sentinel.conf &&
+        echo 'sentinel down-after-milliseconds wal-master 5000' >> /tmp/sentinel.conf &&
+        echo 'sentinel failover-timeout wal-master 10000' >> /tmp/sentinel.conf &&
+        echo 'sentinel parallel-syncs wal-master 1' >> /tmp/sentinel.conf &&
         redis-server /tmp/sentinel.conf --sentinel --port 26379
       "
     healthcheck:
@@ -42,7 +47,7 @@ services:
       timeout: 3s
       retries: 15
     depends_on:
-      orch-redis-master:
+      wal-redis-master:
         condition: service_healthy
     restart: unless-stopped
 
@@ -55,16 +60,20 @@ services:
       - MQ_REDIS_PORT=6379
       - MQ_REDIS_PASSWORD=redis
       - MQ_REDIS_DB=0
-      - ORCH_REDIS_PASSWORD=redis
-      - ORCH_REDIS_DB=0
-      - ORCH_SENTINEL_HOSTS=orch-redis-sentinel:26379
-      - ORCH_MASTER_NAME=orch-master
+      # Decoupled WAL store — same shared wal-redis used by all services
+      - WAL_REDIS_HOST=wal-redis-master
+      - WAL_REDIS_PORT=6379
+      - WAL_REDIS_PASSWORD=redis
+      - WAL_REDIS_DB=0
+      - WAL_SENTINEL_HOSTS=wal-redis-sentinel:26379
+      - WAL_MASTER_NAME=wal-master
       - ORCH_MAX_RETRIES=3
       - ORCH_TASK_TIMEOUT_S=5
+      - ORCH_CONSUMER_NAME=orchestrator-1
     depends_on:
       mq-redis:
         condition: service_healthy
-      orch-redis-sentinel:
+      wal-redis-sentinel:
         condition: service_healthy
     restart: unless-stopped
 
@@ -76,16 +85,19 @@ services:
       - MQ_REDIS_PORT=6379
       - MQ_REDIS_PASSWORD=redis
       - MQ_REDIS_DB=0
-      - ORCH_REDIS_PASSWORD=redis
-      - ORCH_REDIS_DB=0
-      - ORCH_SENTINEL_HOSTS=orch-redis-sentinel:26379
-      - ORCH_MASTER_NAME=orch-master
+      - WAL_REDIS_HOST=wal-redis-master
+      - WAL_REDIS_PORT=6379
+      - WAL_REDIS_PASSWORD=redis
+      - WAL_REDIS_DB=0
+      - WAL_SENTINEL_HOSTS=wal-redis-sentinel:26379
+      - WAL_MASTER_NAME=wal-master
       - ORCH_MAX_RETRIES=3
       - ORCH_TASK_TIMEOUT_S=5
+      - ORCH_CONSUMER_NAME=orchestrator-2
     depends_on:
       mq-redis:
         condition: service_healthy
-      orch-redis-sentinel:
+      wal-redis-sentinel:
         condition: service_healthy
     restart: unless-stopped
 
@@ -132,11 +144,20 @@ services:
       - REDIS_DB=0
       - REDIS_SENTINEL_HOSTS=order-redis-sentinel:26379
       - REDIS_MASTER_NAME=order-master
+      # Decoupled WAL store — separate from business data Redis
+      - WAL_REDIS_HOST=wal-redis-master
+      - WAL_REDIS_PORT=6379
+      - WAL_REDIS_PASSWORD=redis
+      - WAL_REDIS_DB=0
+      - WAL_SENTINEL_HOSTS=wal-redis-sentinel:26379
+      - WAL_MASTER_NAME=wal-master
     command: gunicorn -b 0.0.0.0:5000 -w 4 --timeout 70 --log-level=info app:app
     depends_on:
       mq-redis:
         condition: service_healthy
       order-redis-sentinel:
+        condition: service_healthy
+      wal-redis-sentinel:
         condition: service_healthy
     restart: unless-stopped
 
@@ -156,11 +177,19 @@ services:
       - REDIS_DB=0
       - REDIS_SENTINEL_HOSTS=order-redis-sentinel:26379
       - REDIS_MASTER_NAME=order-master
+      - WAL_REDIS_HOST=wal-redis-master
+      - WAL_REDIS_PORT=6379
+      - WAL_REDIS_PASSWORD=redis
+      - WAL_REDIS_DB=0
+      - WAL_SENTINEL_HOSTS=wal-redis-sentinel:26379
+      - WAL_MASTER_NAME=wal-master
     command: gunicorn -b 0.0.0.0:5000 -w 4 --timeout 70 --log-level=info app:app
     depends_on:
       mq-redis:
         condition: service_healthy
       order-redis-sentinel:
+        condition: service_healthy
+      wal-redis-sentinel:
         condition: service_healthy
     restart: unless-stopped
 
@@ -225,11 +254,19 @@ services:
       - REDIS_DB=0
       - REDIS_SENTINEL_HOSTS=stock-redis-sentinel:26379
       - REDIS_MASTER_NAME=stock-master
+      - WAL_REDIS_HOST=wal-redis-master
+      - WAL_REDIS_PORT=6379
+      - WAL_REDIS_PASSWORD=redis
+      - WAL_REDIS_DB=0
+      - WAL_SENTINEL_HOSTS=wal-redis-sentinel:26379
+      - WAL_MASTER_NAME=wal-master
     command: gunicorn -b 0.0.0.0:5000 -w 4 --timeout 30 --log-level=info app:app
     depends_on:
       mq-redis:
         condition: service_healthy
       stock-redis-sentinel:
+        condition: service_healthy
+      wal-redis-sentinel:
         condition: service_healthy
     restart: unless-stopped
 
@@ -247,11 +284,19 @@ services:
       - REDIS_DB=0
       - REDIS_SENTINEL_HOSTS=stock-redis-sentinel:26379
       - REDIS_MASTER_NAME=stock-master
+      - WAL_REDIS_HOST=wal-redis-master
+      - WAL_REDIS_PORT=6379
+      - WAL_REDIS_PASSWORD=redis
+      - WAL_REDIS_DB=0
+      - WAL_SENTINEL_HOSTS=wal-redis-sentinel:26379
+      - WAL_MASTER_NAME=wal-master
     command: gunicorn -b 0.0.0.0:5000 -w 4 --timeout 30 --log-level=info app:app
     depends_on:
       mq-redis:
         condition: service_healthy
       stock-redis-sentinel:
+        condition: service_healthy
+      wal-redis-sentinel:
         condition: service_healthy
     restart: unless-stopped
 
@@ -316,11 +361,19 @@ services:
       - REDIS_DB=0
       - REDIS_SENTINEL_HOSTS=payment-redis-sentinel:26379
       - REDIS_MASTER_NAME=payment-master
+      - WAL_REDIS_HOST=wal-redis-master
+      - WAL_REDIS_PORT=6379
+      - WAL_REDIS_PASSWORD=redis
+      - WAL_REDIS_DB=0
+      - WAL_SENTINEL_HOSTS=wal-redis-sentinel:26379
+      - WAL_MASTER_NAME=wal-master
     command: gunicorn -b 0.0.0.0:5000 -w 4 --timeout 30 --log-level=info app:app
     depends_on:
       mq-redis:
         condition: service_healthy
       payment-redis-sentinel:
+        condition: service_healthy
+      wal-redis-sentinel:
         condition: service_healthy
     restart: unless-stopped
 
@@ -338,11 +391,19 @@ services:
       - REDIS_DB=0
       - REDIS_SENTINEL_HOSTS=payment-redis-sentinel:26379
       - REDIS_MASTER_NAME=payment-master
+      - WAL_REDIS_HOST=wal-redis-master
+      - WAL_REDIS_PORT=6379
+      - WAL_REDIS_PASSWORD=redis
+      - WAL_REDIS_DB=0
+      - WAL_SENTINEL_HOSTS=wal-redis-sentinel:26379
+      - WAL_MASTER_NAME=wal-master
     command: gunicorn -b 0.0.0.0:5000 -w 4 --timeout 30 --log-level=info app:app
     depends_on:
       mq-redis:
         condition: service_healthy
       payment-redis-sentinel:
+        condition: service_healthy
+      wal-redis-sentinel:
         condition: service_healthy
     restart: unless-stopped
 
@@ -393,11 +454,11 @@ services:
     restart: unless-stopped
 
 volumes:
+  wal-master-data:
+  wal-replica-data:
   order-master-data:
   order-replica-data:
   stock-master-data:
   stock-replica-data:
   payment-master-data:
   payment-replica-data:
-  orch-master-data:
-  orch-replica-data:

--- a/orchestrator/app.py
+++ b/orchestrator/app.py
@@ -6,6 +6,12 @@ import threading
 
 import redis
 
+from wal import (
+    wal, persist_batch, load_batch, complete_batch,
+    acquire_lock, release_lock, pending_batch_ids, remove_from_pending,
+    PENDING_KEY,
+)
+
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
 logger = logging.getLogger(__name__)
 
@@ -15,20 +21,12 @@ MQ_REDIS_PORT     = int(os.environ['MQ_REDIS_PORT'])
 MQ_REDIS_PASSWORD = os.environ['MQ_REDIS_PASSWORD']
 MQ_REDIS_DB       = int(os.environ['MQ_REDIS_DB'])
 
-ORCH_REDIS_HOST     = os.environ.get('ORCH_REDIS_HOST', '')
-ORCH_REDIS_PORT     = int(os.environ.get('ORCH_REDIS_PORT', '6379'))
-ORCH_REDIS_PASSWORD = os.environ.get('ORCH_REDIS_PASSWORD', '')
-ORCH_REDIS_DB       = int(os.environ.get('ORCH_REDIS_DB', '0'))
-ORCH_SENTINEL_HOSTS = os.environ.get('ORCH_SENTINEL_HOSTS', '')
-ORCH_MASTER_NAME    = os.environ.get('ORCH_MASTER_NAME', 'orch-master')
-
 MAX_RETRIES    = int(os.environ.get('ORCH_MAX_RETRIES', '3'))
 TASK_TIMEOUT_S = int(os.environ.get('ORCH_TASK_TIMEOUT_S', '5'))
 
 ORCH_STREAM   = 'events:orchestrator'
 ORCH_GROUP    = 'orchestrator_group'
-ORCH_CONSUMER = 'orchestrator-1'
-PENDING_KEY   = 'orch:pending'
+ORCH_CONSUMER = os.environ.get('ORCH_CONSUMER_NAME', 'orchestrator-1')
 
 # Task states
 S_PENDING         = 'PENDING'
@@ -46,54 +44,18 @@ B_RUNNING   = 'RUNNING'
 B_COMPLETED = 'COMPLETED'
 B_FAILED    = 'FAILED'
 
-# ── Redis connections ──────────────────────────────────────────────────────────
+# ── MQ connection (transient — not the WAL store) ──────────────────────────────
 mq: redis.Redis = redis.Redis(
     host=MQ_REDIS_HOST, port=MQ_REDIS_PORT,
     password=MQ_REDIS_PASSWORD, db=MQ_REDIS_DB,
 )
-
-if ORCH_SENTINEL_HOSTS:
-    from redis.sentinel import Sentinel as _Sentinel
-    from redis.retry import Retry
-    from redis.backoff import NoBackoff
-    _orch_peers = [(h.split(':')[0], int(h.split(':')[1])) for h in ORCH_SENTINEL_HOSTS.split(',')]
-    orch: redis.Redis = _Sentinel(
-        _orch_peers,
-        password=ORCH_REDIS_PASSWORD,
-        db=ORCH_REDIS_DB,
-        socket_timeout=1.5,
-        socket_connect_timeout=1.5,
-    ).master_for(
-        ORCH_MASTER_NAME,
-        socket_timeout=1.5,
-        socket_connect_timeout=1.5,
-        retry=Retry(NoBackoff(), 3),
-        retry_on_error=[redis.exceptions.ConnectionError, redis.exceptions.TimeoutError,
-                        redis.exceptions.ReadOnlyError],
-    )
-else:
-    orch: redis.Redis = redis.Redis(
-        host=ORCH_REDIS_HOST, port=ORCH_REDIS_PORT,
-        password=ORCH_REDIS_PASSWORD, db=ORCH_REDIS_DB,
-    )
-
-# ── WAL helpers ────────────────────────────────────────────────────────────────
-def _wal_key(batch_id: str) -> str:
-    return f'orch:batch:{batch_id}'
-
-def _persist_batch(batch: dict):
-    orch.set(_wal_key(batch['batch_id']), json.dumps(batch))
-
-def _load_batch(batch_id: str) -> dict | None:
-    raw = orch.get(_wal_key(batch_id))
-    return json.loads(raw) if raw else None
 
 # ── Task dispatch ──────────────────────────────────────────────────────────────
 def dispatch_task(task: dict) -> dict:
     """
     Send one task to its target stream and block on a per-attempt reply key.
     Retries up to MAX_RETRIES times on timeout only.
-    Any response (200 or non-200) is final — no retry.
+    Any response (200 or non-200) is final — no retry on error responses.
     Returns updated task dict with final state.
     """
     task_id = task['task_id']
@@ -112,23 +74,25 @@ def dispatch_task(task: dict) -> dict:
                 val = json.loads(resp[1])
                 status_code = val.get('status_code', 500)
                 state = S_DELIVERED_OK if status_code == 200 else S_DELIVERED_ERR
-                logger.info(f'Task {task_id} attempt {attempt}: {state} (code={status_code})')
+                logger.info('Task %s attempt %d: %s (code=%s)', task_id, attempt, state, status_code)
                 return {**task, 'state': state, 'status_code': status_code,
                         'body': val.get('body'), 'error': val.get('error')}
             else:
-                logger.warning(f'Task {task_id} attempt {attempt} timed out, retrying')
-        except Exception as e:
-            logger.error(f'Task {task_id} attempt {attempt} exception: {e}')
+                logger.warning('Task %s attempt %d timed out, retrying', task_id, attempt)
+        except Exception as exc:
+            logger.error('Task %s attempt %d exception: %s', task_id, attempt, exc)
 
-    logger.error(f'Task {task_id} DELIVERY_FAILED after {MAX_RETRIES} attempts')
+    logger.error('Task %s DELIVERY_FAILED after %d attempts', task_id, MAX_RETRIES)
     return {**task, 'state': S_DELIVERY_FAILED, 'status_code': None, 'body': None,
             'error': f'No response after {MAX_RETRIES} attempts'}
+
 
 # ── Batch processor ────────────────────────────────────────────────────────────
 def _all_terminal(tasks_by_id: dict) -> bool:
     return all(t['state'] in TERMINAL_STATES for t in tasks_by_id.values())
 
-def _cascade_skipped(tasks_by_id: dict):
+
+def _cascade_skipped(tasks_by_id: dict) -> None:
     """Propagate SKIPPED to tasks whose dependency ended in a failure state."""
     changed = True
     while changed:
@@ -140,14 +104,26 @@ def _cascade_skipped(tasks_by_id: dict):
                 dep = tasks_by_id.get(dep_id)
                 if dep and dep['state'] in FAILURE_STATES:
                     task['state'] = S_SKIPPED
-                    logger.info(f'Task {task["task_id"]} SKIPPED (dep {dep_id} → {dep["state"]})')
+                    logger.info('Task %s SKIPPED (dep %s → %s)',
+                                task['task_id'], dep_id, dep['state'])
                     changed = True
                     break
 
-def process_batch(batch: dict):
+
+def process_batch(batch: dict) -> None:
     """
-    Wave-based dependency executor.  Runs in its own daemon thread per batch.
-    Persists state to WAL after every wave so recovery can resume mid-flight.
+    Wave-based dependency executor. Runs in its own daemon thread per batch.
+
+    WAL contract (all writes go to wal-redis via wal.py):
+      1. persist_batch() is called with status=IN_PROGRESS BEFORE dispatching
+         each wave, so a crash during dispatch leaves the WAL in a state that
+         recovery can re-drive (tasks reset from IN_PROGRESS → PENDING).
+      2. persist_batch() is called again AFTER each wave with the results.
+      3. complete_batch() is called on final success or failure; it updates the
+         JSON snapshot and removes the batch from wal:orch:pending.
+
+    The MQ reply (rpush to reply_to) happens AFTER the WAL write, so the caller
+    (order service) only gets a result once the WAL is settled.
     """
     batch_id = batch['batch_id']
     reply_to = batch['reply_to']
@@ -159,7 +135,7 @@ def process_batch(batch: dict):
     else:
         tasks_by_id = {k: dict(v) for k, v in raw_tasks.items()}
 
-    logger.info(f'process_batch {batch_id}: {len(tasks_by_id)} task(s)')
+    logger.info('process_batch %s: %d task(s)', batch_id, len(tasks_by_id))
 
     while not _all_terminal(tasks_by_id):
         _cascade_skipped(tasks_by_id)
@@ -177,20 +153,31 @@ def process_batch(batch: dict):
         ]
 
         if not ready:
-            logger.error(f'process_batch {batch_id}: no progress possible, marking remaining DELIVERY_FAILED')
+            logger.error('process_batch %s: no progress possible, marking remaining DELIVERY_FAILED', batch_id)
             for t in tasks_by_id.values():
                 if t['state'] == S_PENDING:
                     t['state'] = S_DELIVERY_FAILED
                     t['error'] = 'Deadlock: no progress possible'
             break
 
-        # Mark IN_PROGRESS and persist WAL before dispatching
+        # ── Pre-wave WAL write ─────────────────────────────────────────────────
+        # Mark tasks IN_PROGRESS and persist to WAL *before* dispatching.
+        # If we crash during dispatch, recovery sees IN_PROGRESS and resets to PENDING.
         for t in ready:
             tasks_by_id[t['task_id']]['state'] = S_IN_PROGRESS
         batch['tasks'] = tasks_by_id
-        _persist_batch(batch)
+        try:
+            persist_batch(batch)
+        except redis.exceptions.RedisError:
+            logger.error('process_batch %s: cannot write pre-wave WAL, aborting batch', batch_id)
+            # Cannot proceed safely without a WAL entry — mark failed and exit.
+            for t in tasks_by_id.values():
+                if t['state'] == S_IN_PROGRESS:
+                    t['state'] = S_DELIVERY_FAILED
+                    t['error'] = 'WAL write failed before dispatch'
+            break
 
-        # Dispatch ready tasks concurrently
+        # ── Dispatch ready tasks concurrently ─────────────────────────────────
         results: list[dict] = []
         lock = threading.Lock()
 
@@ -210,105 +197,132 @@ def process_batch(batch: dict):
             tasks_by_id[r['task_id']] = r
         _cascade_skipped(tasks_by_id)
 
-        # Persist WAL after wave
+        # ── Post-wave WAL write ────────────────────────────────────────────────
         batch['tasks'] = tasks_by_id
-        _persist_batch(batch)
+        try:
+            persist_batch(batch)
+        except redis.exceptions.RedisError:
+            logger.error('process_batch %s: cannot write post-wave WAL (continuing)', batch_id)
 
-    # Compute final batch status
+    # ── Finalise ───────────────────────────────────────────────────────────────
     has_delivery_failed = any(t['state'] == S_DELIVERY_FAILED for t in tasks_by_id.values())
     batch_status = B_FAILED if has_delivery_failed else B_COMPLETED
     batch['status'] = batch_status
+    batch['tasks']  = tasks_by_id
 
-    # Build result payload (omit internal payload field)
     result_tasks = {
         tid: {
-            'state': t['state'],
+            'state':       t['state'],
             'status_code': t.get('status_code'),
-            'body': t.get('body'),
-            'error': t.get('error'),
+            'body':        t.get('body'),
+            'error':       t.get('error'),
         }
         for tid, t in tasks_by_id.items()
     }
     reply_payload = json.dumps({
         'batch_id': batch_id,
-        'status': batch_status,
-        'tasks': result_tasks,
+        'status':   batch_status,
+        'tasks':    result_tasks,
     })
 
     try:
+        # Write final WAL state (removes from pending) before replying to caller.
+        complete_batch(batch)
         mq.rpush(reply_to, reply_payload)
         mq.expire(reply_to, 120)
-        orch.srem(PENDING_KEY, batch_id)
-        batch['tasks'] = tasks_by_id
-        _persist_batch(batch)
-    except Exception as e:
-        logger.error(f'process_batch {batch_id}: failed to push reply or clean WAL: {e}')
+    except Exception as exc:
+        logger.error('process_batch %s: failed to complete WAL or push reply: %s', batch_id, exc)
+        # Best-effort: try pushing the reply even if WAL cleanup failed.
+        # wal:orch:pending still holds the batch_id; recovery will re-drive
+        # (idempotent) and clean up on next startup.
+        try:
+            mq.rpush(reply_to, reply_payload)
+            mq.expire(reply_to, 120)
+        except Exception:
+            pass
 
-    logger.info(f'process_batch {batch_id}: {batch_status}')
+    logger.info('process_batch %s: %s', batch_id, batch_status)
+
 
 # ── Recovery ───────────────────────────────────────────────────────────────────
-def recover_batches():
-    time.sleep(5)
-    try:
-        pending = orch.smembers(PENDING_KEY)
-    except Exception as e:
-        logger.error(f'Recovery: cannot read pending set: {e}')
-        return
+def recover_batches() -> None:
+    """
+    Startup recovery sweep. Reads wal:orch:pending from wal-redis and
+    re-dispatches any batch that was in-flight when a previous instance crashed.
 
-    if not pending:
+    Uses distributed locks (wal:orch:lock:{batch_id}) so two orchestrator
+    replicas racing at startup do not both re-drive the same batch.
+
+    Participant services are all idempotent (tombstone / WAL state machine),
+    so re-driving a batch that was partially completed is safe.
+    """
+    time.sleep(5)  # give other services time to come up first
+
+    batch_ids = pending_batch_ids()
+    if not batch_ids:
         logger.info('Recovery: no in-flight batches')
         return
 
-    logger.info(f'Recovery: found {len(pending)} in-flight batch(es)')
+    logger.info('Recovery: found %d in-flight batch(es)', len(batch_ids))
 
-    for batch_id_bytes in pending:
-        batch_id = batch_id_bytes.decode()
-        lock_key = f'orch:lock:{batch_id}'
-        if not orch.set(lock_key, 'locked', nx=True, ex=30):
-            continue  # another instance claimed this batch
+    for batch_id in batch_ids:
+        if not acquire_lock(batch_id):
+            logger.info('Recovery: batch %s claimed by another instance, skipping', batch_id)
+            continue
 
         try:
-            batch = _load_batch(batch_id)
+            batch = load_batch(batch_id)
             if not batch:
-                logger.warning(f'Recovery: batch {batch_id} not found in WAL, removing from pending')
-                orch.srem(PENDING_KEY, batch_id)
+                logger.warning('Recovery: batch %s not found in WAL, removing from pending', batch_id)
+                remove_from_pending(batch_id)
                 continue
 
             if batch.get('status') in (B_COMPLETED, B_FAILED):
-                # Terminal but pending set not cleaned — just clean up
-                orch.srem(PENDING_KEY, batch_id)
+                # Terminal but pending set was not cleaned — just clean up.
+                remove_from_pending(batch_id)
                 continue
 
             # Reset any IN_PROGRESS tasks to PENDING so they are re-dispatched.
-            # Participant idempotency (tombstones) prevents double-apply.
+            # Participant idempotency (tombstones / WAL state machines in wal-redis)
+            # prevents double-apply of already-committed tasks.
             tasks = batch.get('tasks', {})
             if isinstance(tasks, dict):
                 for t in tasks.values():
                     if t.get('state') == S_IN_PROGRESS:
                         t['state'] = S_PENDING
-                        logger.info(f'Recovery: reset task {t["task_id"]} to PENDING')
+                        logger.info('Recovery: reset task %s to PENDING', t['task_id'])
                 batch['tasks'] = tasks
 
-            logger.info(f'Recovery: re-dispatching batch {batch_id}')
+            logger.info('Recovery: re-dispatching batch %s', batch_id)
             threading.Thread(target=process_batch, args=(batch,), daemon=True).start()
-        except Exception as e:
-            logger.error(f'Recovery: failed to process batch {batch_id}: {e}')
+
+        except Exception as exc:
+            logger.error('Recovery: failed to process batch %s: %s', batch_id, exc)
         finally:
-            orch.delete(lock_key)
+            release_lock(batch_id)
+
 
 # ── Stream listener ────────────────────────────────────────────────────────────
-def run_listener():
-    # Create consumer group idempotently
+def run_listener() -> None:
+    """
+    Consume messages from events:orchestrator stream.
+    For each submit_batch message:
+      1. Build batch dict with all tasks in PENDING state.
+      2. Write to WAL (persist_batch) and add to wal:orch:pending BEFORE
+         spawning the processing thread. This guarantees the batch is
+         recoverable even if the process crashes between accept and dispatch.
+      3. Spawn a daemon thread to process the batch.
+    """
     try:
         mq.xgroup_create(ORCH_STREAM, ORCH_GROUP, id='0', mkstream=True)
-        logger.info(f'Created consumer group {ORCH_GROUP} on {ORCH_STREAM}')
-    except redis.exceptions.ResponseError as e:
-        if 'BUSYGROUP' in str(e):
-            logger.info(f'Consumer group {ORCH_GROUP} already exists')
+        logger.info('Created consumer group %s on %s', ORCH_GROUP, ORCH_STREAM)
+    except redis.exceptions.ResponseError as exc:
+        if 'BUSYGROUP' in str(exc):
+            logger.info('Consumer group %s already exists', ORCH_GROUP)
         else:
             raise
 
-    logger.info('Orchestrator listener started')
+    logger.info('Orchestrator listener started (consumer=%s)', ORCH_CONSUMER)
 
     while True:
         try:
@@ -325,7 +339,7 @@ def run_listener():
                     try:
                         msg_type = fields.get(b'type', b'').decode()
                         if msg_type != 'submit_batch':
-                            logger.warning(f'Unknown message type: {msg_type} (id={msg_id})')
+                            logger.warning('Unknown message type: %s (id=%s)', msg_type, msg_id)
                             continue
 
                         batch_id = fields[b'batch_id'].decode()
@@ -354,26 +368,37 @@ def run_listener():
                             'tasks': tasks,
                         }
 
-                        _persist_batch(batch)
-                        orch.sadd(PENDING_KEY, batch_id)
+                        # Write WAL entry BEFORE spawning the processing thread.
+                        # If we crash after this write, recovery will find and
+                        # re-drive the batch. If persist_batch fails, we skip
+                        # spawning — the caller will time out and retry.
+                        try:
+                            persist_batch(batch)
+                        except redis.exceptions.RedisError as exc:
+                            logger.error('Cannot write WAL for batch %s: %s — dropping', batch_id, exc)
+                            continue
+
                         threading.Thread(
                             target=process_batch, args=(batch,), daemon=True
                         ).start()
-                        logger.info(f'Accepted batch {batch_id}')
-                    except Exception as e:
-                        logger.error(f'Error processing message {msg_id}: {e}')
+                        logger.info('Accepted batch %s', batch_id)
 
-        except redis.exceptions.ConnectionError as e:
-            logger.error(f'Connection error in listener: {e}')
+                    except Exception as exc:
+                        logger.error('Error processing message %s: %s', msg_id, exc)
+
+        except redis.exceptions.ConnectionError as exc:
+            logger.error('Connection error in listener: %s', exc)
             time.sleep(1)
-        except Exception as e:
-            logger.error(f'Listener error: {e}')
+        except Exception as exc:
+            logger.error('Listener error: %s', exc)
             time.sleep(1)
+
 
 # ── Entry point ────────────────────────────────────────────────────────────────
-def main():
+def main() -> None:
     threading.Thread(target=recover_batches, daemon=True).start()
     run_listener()
+
 
 if __name__ == '__main__':
     main()

--- a/orchestrator/wal.py
+++ b/orchestrator/wal.py
@@ -1,0 +1,167 @@
+"""
+wal.py — Decoupled Write-Ahead Log connection for the orchestrator service.
+
+All orchestrator WAL entries live in the shared wal-redis cluster, which is
+completely independent of the orchestrator containers and the MQ Redis.
+Killing both orchestrator-1 and orchestrator-2 does not touch wal-redis.
+
+Key namespace (all prefixed wal:orch: to avoid collisions with service WALs):
+  wal:orch:pending               → Redis Set  (batch_ids currently in-flight)
+  wal:orch:batch:{batch_id}      → String     (JSON snapshot of full batch state)
+  wal:orch:lock:{batch_id}       → String/TTL (recovery mutex, expires in 30s)
+
+Design:
+  - _persist_batch() is the only write path for batch state. It is always called
+    BEFORE dispatching tasks (pre-write) and AFTER each wave (post-write), so
+    the WAL always reflects at least what has been attempted, never what hasn't.
+  - wal:orch:pending is written atomically with the first _persist_batch() call
+    so recovery can find batches even if the orchestrator crashes before the
+    listener loop acks the message.
+  - On completion/failure, wal:orch:pending entry is removed and the batch JSON
+    is updated with the final status. The JSON is kept (not deleted) for a short
+    TTL so callers can inspect it post-completion if needed.
+"""
+
+import json
+import logging
+import os
+
+import redis
+from redis.retry import Retry
+from redis.backoff import NoBackoff
+
+logger = logging.getLogger(__name__)
+
+# ── Key helpers ────────────────────────────────────────────────────────────────
+
+PENDING_KEY = 'wal:orch:pending'
+
+
+def _batch_key(batch_id: str) -> str:
+    return f'wal:orch:batch:{batch_id}'
+
+
+def _lock_key(batch_id: str) -> str:
+    return f'wal:orch:lock:{batch_id}'
+
+
+# ── Connection ─────────────────────────────────────────────────────────────────
+
+def _build_wal_connection() -> redis.Redis:
+    password = os.environ.get('WAL_REDIS_PASSWORD', '')
+    db_num   = int(os.environ.get('WAL_REDIS_DB', '0'))
+    sentinel = os.environ.get('WAL_SENTINEL_HOSTS', '')
+    name     = os.environ.get('WAL_MASTER_NAME', 'wal-master')
+
+    if sentinel:
+        from redis.sentinel import Sentinel as _Sentinel
+        peers = [(h.split(':')[0], int(h.split(':')[1]))
+                 for h in sentinel.split(',')]
+        return _Sentinel(
+            peers,
+            password=password,
+            db=db_num,
+            socket_timeout=1.5,
+            socket_connect_timeout=1.5,
+        ).master_for(
+            name,
+            socket_timeout=1.5,
+            socket_connect_timeout=1.5,
+            retry=Retry(NoBackoff(), 3),
+            retry_on_error=[
+                redis.exceptions.ConnectionError,
+                redis.exceptions.TimeoutError,
+                redis.exceptions.ReadOnlyError,
+            ],
+        )
+
+    return redis.Redis(
+        host=os.environ['WAL_REDIS_HOST'],
+        port=int(os.environ['WAL_REDIS_PORT']),
+        password=password,
+        db=db_num,
+    )
+
+
+# Module-level WAL connection — shared across all threads in this process.
+wal: redis.Redis = _build_wal_connection()
+
+
+# ── WAL operations ─────────────────────────────────────────────────────────────
+
+def persist_batch(batch: dict) -> None:
+    """
+    Append-write the current batch state to wal-redis.
+    Also ensures batch_id is in the wal:orch:pending set.
+    Called before dispatching any tasks (pre-write) and after every wave.
+    """
+    batch_id = batch['batch_id']
+    try:
+        pipe = wal.pipeline(transaction=True)
+        pipe.set(_batch_key(batch_id), json.dumps(batch))
+        pipe.sadd(PENDING_KEY, batch_id)
+        pipe.execute()
+    except redis.exceptions.RedisError as exc:
+        logger.error('WAL persist_batch %s failed: %s', batch_id, exc)
+        raise
+
+
+def load_batch(batch_id: str) -> dict | None:
+    """Read the last persisted snapshot of a batch. Returns None if not found."""
+    try:
+        raw = wal.get(_batch_key(batch_id))
+        return json.loads(raw) if raw else None
+    except redis.exceptions.RedisError as exc:
+        logger.error('WAL load_batch %s failed: %s', batch_id, exc)
+        return None
+
+
+def complete_batch(batch: dict) -> None:
+    """
+    Mark batch as complete in the WAL: update the JSON snapshot and remove
+    from the pending set so recovery ignores it.
+    Sets a 24-hour TTL on the batch key so the record is not kept forever.
+    """
+    batch_id = batch['batch_id']
+    try:
+        pipe = wal.pipeline(transaction=True)
+        pipe.set(_batch_key(batch_id), json.dumps(batch), ex=86400)  # 24h TTL
+        pipe.srem(PENDING_KEY, batch_id)
+        pipe.execute()
+    except redis.exceptions.RedisError as exc:
+        logger.error('WAL complete_batch %s failed: %s', batch_id, exc)
+        # Non-fatal: recovery will find the batch still in wal:orch:pending
+        # and re-drive it (idempotent), then clean up.
+
+
+def acquire_lock(batch_id: str, ttl_s: int = 30) -> bool:
+    """Acquire a recovery lock for batch_id. Returns True if acquired."""
+    try:
+        return bool(wal.set(_lock_key(batch_id), 'locked', nx=True, ex=ttl_s))
+    except redis.exceptions.RedisError:
+        return False
+
+
+def release_lock(batch_id: str) -> None:
+    """Release the recovery lock for batch_id."""
+    try:
+        wal.delete(_lock_key(batch_id))
+    except redis.exceptions.RedisError:
+        pass
+
+
+def pending_batch_ids() -> list[str]:
+    """Return all batch_ids currently in wal:orch:pending."""
+    try:
+        return [b.decode() for b in wal.smembers(PENDING_KEY)]
+    except redis.exceptions.RedisError as exc:
+        logger.error('WAL pending_batch_ids failed: %s', exc)
+        return []
+
+
+def remove_from_pending(batch_id: str) -> None:
+    """Remove a batch_id from the pending set without touching the batch JSON."""
+    try:
+        wal.srem(PENDING_KEY, batch_id)
+    except redis.exceptions.RedisError as exc:
+        logger.warning('WAL remove_from_pending %s failed: %s', batch_id, exc)

--- a/order/app.py
+++ b/order/app.py
@@ -13,12 +13,13 @@ from msgspec import msgpack
 
 from db import (db, mq, OrderValue, get_order,
                 STATUS_PENDING, DB_ERROR_STR)
+from wal import wal
 from rpc import send_rpc
 from saga import checkout_saga, recover_saga
 from twopc import checkout_2pc, recover_2pc
 
 app = Flask("order-service")
-atexit.register(lambda: (db.close(), mq.close()))
+atexit.register(lambda: (db.close(), mq.close(), wal.close()))
 
 # ── Routes ─────────────────────────────────────────────────────────────────────
 

--- a/order/db.py
+++ b/order/db.py
@@ -75,29 +75,34 @@ def save_order(order_id: str, order: OrderValue, *,
                wal_add: str | None = None,
                wal_remove: str | None = None):
     """
-    Persist order to business-data Redis.
-    WAL set updates (wal_add / wal_remove) go to the decoupled wal-redis.
+    Persist order to business-data Redis with optional WAL set updates.
 
-    Order of operations:
-      1. Write order to db (business Redis) atomically.
-      2. Update WAL set in wal-redis separately.
-    Step 2 is best-effort only for wal_remove (cleanup); for wal_add it
-    is required — callers should treat a RedisError on wal_add as fatal.
+    WAL-before-act ordering:
+      1. Write WAL entry to wal-redis first (if wal_add is set).
+      2. Write order to db-redis.
+      3. Remove WAL entry from wal-redis (if wal_remove is set, best-effort).
     """
     from wal import wal as _wal
 
-    # Step 1: persist business data
-    try:
-        db.set(order_id, msgpack.encode(order))
-    except redis.exceptions.RedisError:
-        raise  # caller handles
-
-    # Step 2: update WAL in separate store
+    # Step 1: write WAL entry before touching db
     try:
         if wal_add:
             _wal.sadd(wal_add, order_id)
-        if wal_remove:
-            _wal.srem(wal_remove, order_id)
     except redis.exceptions.RedisError:
-        if wal_add:
-            raise  # cannot afford to lose a WAL entry on add
+        raise  # cannot proceed without a WAL entry
+
+    # Step 2: persist business data
+    try:
+        db.set(order_id, msgpack.encode(order))
+    except redis.exceptions.RedisError:
+        # db write failed — the WAL entry we just added is an orphan.
+        # Recovery will find it, read STATUS_PENDING (unchanged) or a missing
+        # order in db, and clean up safely. Re-raise so the caller aborts.
+        raise
+
+    # Step 3: best-effort WAL cleanup
+    if wal_remove:
+        try:
+            _wal.srem(wal_remove, order_id)
+        except redis.exceptions.RedisError:
+            pass  # non-fatal: recovery will clean up on next startup

--- a/order/db.py
+++ b/order/db.py
@@ -10,8 +10,10 @@ STATUS_STARTED = "started"
 STATUS_PAID    = "paid"
 STATUS_FAILED  = "failed"
 
-COORD_PENDING_KEY = "2pc:pending"
-SAGA_PENDING_KEY  = "saga:pending"
+# WAL keys now live in wal-redis (imported from wal.py).
+# These names are kept here as aliases so the rest of the codebase
+# can import them from db without touching their call sites.
+from wal import COORD_PENDING_KEY, SAGA_PENDING_KEY  # noqa: E402
 
 # ── Connections ────────────────────────────────────────────────────────────────
 _REDIS_PASSWORD    = os.environ.get('REDIS_PASSWORD', '')
@@ -72,11 +74,30 @@ def get_order(order_id: str) -> OrderValue:
 def save_order(order_id: str, order: OrderValue, *,
                wal_add: str | None = None,
                wal_remove: str | None = None):
-    """Atomically persist order with an optional WAL set update. Raises RedisError."""
-    with db.pipeline(transaction=True) as pipe:
-        pipe.set(order_id, msgpack.encode(order))
+    """
+    Persist order to business-data Redis.
+    WAL set updates (wal_add / wal_remove) go to the decoupled wal-redis.
+
+    Order of operations:
+      1. Write order to db (business Redis) atomically.
+      2. Update WAL set in wal-redis separately.
+    Step 2 is best-effort only for wal_remove (cleanup); for wal_add it
+    is required — callers should treat a RedisError on wal_add as fatal.
+    """
+    from wal import wal as _wal
+
+    # Step 1: persist business data
+    try:
+        db.set(order_id, msgpack.encode(order))
+    except redis.exceptions.RedisError:
+        raise  # caller handles
+
+    # Step 2: update WAL in separate store
+    try:
         if wal_add:
-            pipe.sadd(wal_add, order_id)
+            _wal.sadd(wal_add, order_id)
         if wal_remove:
-            pipe.srem(wal_remove, order_id)
-        pipe.execute()
+            _wal.srem(wal_remove, order_id)
+    except redis.exceptions.RedisError:
+        if wal_add:
+            raise  # cannot afford to lose a WAL entry on add

--- a/order/saga.py
+++ b/order/saga.py
@@ -7,12 +7,10 @@ from msgspec import msgpack
 from db import (db, OrderValue, get_order, save_order,
                 STATUS_PAID, STATUS_FAILED, STATUS_STARTED,
                 SAGA_PENDING_KEY, DB_ERROR_STR)
+from wal import wal, SAGA_TX_PREFIX, SAGA_ATTEMPT_PREFIX
 from rpc import submit_batch, recovery_rpc, task_ok, task_error
 
 log = logging.getLogger('order-service')
-
-SAGA_TX_PREFIX = "saga:tx:"           # + order_id → per-attempt transaction_id
-SAGA_ATTEMPT_PREFIX = "saga:attempt:" # + order_id → monotonic attempt counter
 
 
 # ── Task graph ─────────────────────────────────────────────────────────────────
@@ -50,9 +48,9 @@ def checkout_saga(order_id: str) -> Response:
 
     # Fresh transaction ID per attempt so tombstones don't block retries.
     try:
-        attempt = db.incr(f"{SAGA_ATTEMPT_PREFIX}{order_id}")
+        attempt = wal.incr(f"{SAGA_ATTEMPT_PREFIX}{order_id}")
         tx_id = f"{order_id}_{attempt}"
-        db.set(f"{SAGA_TX_PREFIX}{order_id}", tx_id)
+        wal.set(f"{SAGA_TX_PREFIX}{order_id}", tx_id)
     except redis.exceptions.RedisError:
         abort(500, DB_ERROR_STR)
 
@@ -100,7 +98,7 @@ def checkout_saga(order_id: str) -> Response:
 
 def recover_saga():
     try:
-        pending = db.smembers(SAGA_PENDING_KEY)
+        pending = wal.smembers(SAGA_PENDING_KEY)
     except redis.exceptions.RedisError as e:
         log.error("Saga recovery: cannot read WAL: %s", e)
         return
@@ -111,24 +109,24 @@ def recover_saga():
 
     for raw_id in pending:
         order_id = raw_id.decode()
-        lock_key = f"recovery_lock_saga:{order_id}"
-        if not db.set(lock_key, "locked", nx=True, ex=30):
+        lock_key = f"wal:order:saga:recovery_lock:{order_id}"
+        if not wal.set(lock_key, "locked", nx=True, ex=30):
             continue
 
         try:
             raw = db.get(order_id)
             if not raw:
-                db.srem(SAGA_PENDING_KEY, order_id)
+                wal.srem(SAGA_PENDING_KEY, order_id)
                 continue
 
             order = msgpack.decode(raw, type=OrderValue)
 
             if order.status != STATUS_STARTED:
-                db.srem(SAGA_PENDING_KEY, order_id)
+                wal.srem(SAGA_PENDING_KEY, order_id)
                 continue
 
-            # Read per-attempt tx_id; fall back to order_id for backward compat.
-            raw_tx = db.get(f"{SAGA_TX_PREFIX}{order_id}")
+            # Read per-attempt tx_id from WAL store; fall back to order_id.
+            raw_tx = wal.get(f"{SAGA_TX_PREFIX}{order_id}")
             tx_id = raw_tx.decode() if raw_tx else order_id
 
             log.warning("Saga recovery: rolling back order %s (tx=%s)", order_id, tx_id)
@@ -146,4 +144,4 @@ def recover_saga():
         except Exception as e:
             log.error("Saga recovery: error processing %s: %s", order_id, e)
         finally:
-            db.delete(lock_key)
+            wal.delete(lock_key)

--- a/order/twopc.py
+++ b/order/twopc.py
@@ -43,6 +43,19 @@ def _commit_tasks(order_id: str, order: OrderValue) -> list:
 # ── Checkout ───────────────────────────────────────────────────────────────────
 
 def checkout_2pc(order_id: str) -> Response:
+    # ── WAL-before-act ─────────────────────────────────────────────────────────
+    # Write the WAL entry BEFORE committing STATUS_STARTED to db. This is the
+    # critical ordering: if we crash after the WAL write but before db.execute(),
+    # recovery finds the WAL entry, reads STATUS_PENDING (or missing) in db, and
+    # aborts cleanly. The reverse order (db first, WAL second) creates a window
+    # where the order is stuck in STATUS_STARTED with no WAL entry — recovery
+    # never finds it, and the next checkout attempt hits the STATUS_STARTED guard
+    # and returns 400 forever.
+    try:
+        wal.sadd(COORD_PENDING_KEY, order_id)
+    except redis.exceptions.RedisError:
+        abort(500, DB_ERROR_STR)
+
     # WATCH so only one gunicorn worker can claim a STATUS_PENDING order.
     try:
         with db.pipeline() as pipe:
@@ -52,13 +65,16 @@ def checkout_2pc(order_id: str) -> Response:
                     raw = pipe.get(order_id)
                     if not raw:
                         pipe.reset()
+                        wal.srem(COORD_PENDING_KEY, order_id)
                         abort(400, f"Order: {order_id} not found!")
                     order = msgpack.decode(raw, type=OrderValue)
                     if order.status == STATUS_PAID:
                         pipe.reset()
+                        wal.srem(COORD_PENDING_KEY, order_id)
                         return Response("Checkout successful", status=200)
                     if order.status == STATUS_STARTED:
                         pipe.reset()
+                        # WAL entry already existed (prior attempt) — leave it.
                         abort(400, f"Order {order_id} is in state: {order.status}")
                     # STATUS_FAILED orders can be retried (e.g. after adding stock/credit)
                     order.status = STATUS_STARTED
@@ -69,12 +85,12 @@ def checkout_2pc(order_id: str) -> Response:
                 except redis.WatchError:
                     continue
     except redis.exceptions.RedisError:
-        abort(500, DB_ERROR_STR)
-
-    # Write the WAL entry to the decoupled wal-redis AFTER claiming the order.
-    try:
-        wal.sadd(COORD_PENDING_KEY, order_id)
-    except redis.exceptions.RedisError:
+        # db claim failed — remove the WAL entry we added above so we don't
+        # leave a ghost entry pointing at an order that never moved to STARTED.
+        try:
+            wal.srem(COORD_PENDING_KEY, order_id)
+        except redis.exceptions.RedisError:
+            pass
         abort(500, DB_ERROR_STR)
 
     # Phase 1: PREPARE (both participants in parallel)

--- a/order/twopc.py
+++ b/order/twopc.py
@@ -8,6 +8,7 @@ from msgspec import msgpack
 from db import (db, OrderValue, get_order, save_order,
                 STATUS_PAID, STATUS_FAILED, STATUS_STARTED,
                 COORD_PENDING_KEY, DB_ERROR_STR)
+from wal import wal
 from rpc import submit_batch, recovery_rpc, task_ok, task_error
 
 log = logging.getLogger('order-service')
@@ -63,11 +64,16 @@ def checkout_2pc(order_id: str) -> Response:
                     order.status = STATUS_STARTED
                     pipe.multi()
                     pipe.set(order_id, msgpack.encode(order))
-                    pipe.sadd(COORD_PENDING_KEY, order_id)
                     pipe.execute()
                     break
                 except redis.WatchError:
                     continue
+    except redis.exceptions.RedisError:
+        abort(500, DB_ERROR_STR)
+
+    # Write the WAL entry to the decoupled wal-redis AFTER claiming the order.
+    try:
+        wal.sadd(COORD_PENDING_KEY, order_id)
     except redis.exceptions.RedisError:
         abort(500, DB_ERROR_STR)
 
@@ -105,7 +111,7 @@ def checkout_2pc(order_id: str) -> Response:
         payment_ok = task_ok(commit_result, f"{order_id}:2pc:commit:payment")
         if stock_ok and payment_ok:
             try:
-                db.srem(COORD_PENDING_KEY, order_id)
+                wal.srem(COORD_PENDING_KEY, order_id)
             except redis.exceptions.RedisError:
                 log.warning("Could not remove %s from coordinator WAL", order_id)
 
@@ -127,7 +133,7 @@ def abort_2pc(order_id: str, order: OrderValue):
 
     if stock_ok and payment_ok:
         try:
-            db.srem(COORD_PENDING_KEY, order_id)
+            wal.srem(COORD_PENDING_KEY, order_id)
         except redis.exceptions.RedisError:
             log.warning("Could not remove %s from coordinator WAL", order_id)
 
@@ -136,7 +142,7 @@ def abort_2pc(order_id: str, order: OrderValue):
 
 def recover_2pc():
     try:
-        pending = db.smembers(COORD_PENDING_KEY)
+        pending = wal.smembers(COORD_PENDING_KEY)
     except redis.exceptions.RedisError as e:
         log.error("2PC recovery: cannot read WAL: %s", e)
         return
@@ -147,14 +153,14 @@ def recover_2pc():
 
     for raw_id in pending:
         order_id = raw_id.decode()
-        lock_key = f"recovery_lock_2pc:{order_id}"
-        if not db.set(lock_key, "locked", nx=True, ex=30):
+        lock_key = f"wal:order:2pc:recovery_lock:{order_id}"
+        if not wal.set(lock_key, "locked", nx=True, ex=30):
             continue
 
         try:
             raw = db.get(order_id)
             if not raw:
-                db.srem(COORD_PENDING_KEY, order_id)
+                wal.srem(COORD_PENDING_KEY, order_id)
                 continue
 
             order = msgpack.decode(raw, type=OrderValue)
@@ -165,7 +171,7 @@ def recover_2pc():
                 log.info("2PC recovery: re-driving COMMIT for %s", order_id)
                 if (recovery_rpc('events:stock',   'commit_subtract_batch', stock_p) and
                         recovery_rpc('events:payment', 'commit_pay',            payment_p)):
-                    db.srem(COORD_PENDING_KEY, order_id)
+                    wal.srem(COORD_PENDING_KEY, order_id)
             else:
                 log.info("2PC recovery: re-driving ABORT for %s (status=%s)", order_id, order.status)
                 if (recovery_rpc('events:stock',   'abort_subtract_batch', stock_p) and
@@ -176,6 +182,6 @@ def recover_2pc():
         except Exception as e:
             log.error("2PC recovery: error processing %s: %s", order_id, e)
         finally:
-            db.delete(lock_key)
+            wal.delete(lock_key)
 
     log.info("2PC recovery: complete")

--- a/order/wal.py
+++ b/order/wal.py
@@ -1,0 +1,61 @@
+"""
+wal.py — Decoupled Write-Ahead Log connection for the order service.
+
+Key namespace:
+  wal:order:saga:pending          → Redis Set  (saga in-flight order_ids)
+  wal:order:2pc:pending           → Redis Set  (2pc in-flight order_ids)
+  wal:order:saga:tx:{order_id}    → String     (current tx_id for this saga)
+  wal:order:saga:attempt:{order_id} → String   (monotonic attempt counter)
+"""
+
+import os
+import redis
+from redis.retry import Retry
+from redis.backoff import NoBackoff
+
+# ── WAL key constants ──────────────────────────────────────────────────────────
+SAGA_PENDING_KEY  = "wal:order:saga:pending"
+COORD_PENDING_KEY = "wal:order:2pc:pending"
+
+SAGA_TX_PREFIX      = "wal:order:saga:tx:"       # + order_id
+SAGA_ATTEMPT_PREFIX = "wal:order:saga:attempt:"  # + order_id
+
+
+def _build_wal_connection() -> redis.Redis:
+    password = os.environ.get('WAL_REDIS_PASSWORD', '')
+    db       = int(os.environ.get('WAL_REDIS_DB', '0'))
+    sentinel = os.environ.get('WAL_SENTINEL_HOSTS', '')
+    name     = os.environ.get('WAL_MASTER_NAME', 'wal-master')
+
+    if sentinel:
+        from redis.sentinel import Sentinel as _Sentinel
+        peers = [(h.split(':')[0], int(h.split(':')[1]))
+                 for h in sentinel.split(',')]
+        return _Sentinel(
+            peers,
+            password=password,
+            db=db,
+            socket_timeout=1.5,
+            socket_connect_timeout=1.5,
+        ).master_for(
+            name,
+            socket_timeout=1.5,
+            socket_connect_timeout=1.5,
+            retry=Retry(NoBackoff(), 3),
+            retry_on_error=[
+                redis.exceptions.ConnectionError,
+                redis.exceptions.TimeoutError,
+                redis.exceptions.ReadOnlyError,
+            ],
+        )
+
+    return redis.Redis(
+        host=os.environ['WAL_REDIS_HOST'],
+        port=int(os.environ['WAL_REDIS_PORT']),
+        password=password,
+        db=db,
+    )
+
+
+# Module-level WAL connection — one per gunicorn worker process.
+wal: redis.Redis = _build_wal_connection()

--- a/payment/app.py
+++ b/payment/app.py
@@ -11,9 +11,11 @@ import redis
 from msgspec import msgpack, Struct
 from flask import Flask, jsonify, abort, Response
 
+from wal import wal, _payment_wal_key
+
 DB_ERROR_STR = "DB error"
 
-# 2PC WAL state values stored in Redis
+# 2PC WAL state values stored in wal-redis (decoupled from business data)
 WAL_PREPARED  = b"prepared"
 WAL_COMMITTED = b"committed"
 WAL_ABORTED   = b"aborted"
@@ -65,10 +67,9 @@ mq: redis.Redis = redis.Redis(host=os.environ['MQ_REDIS_HOST'],
 def close_db_connection():
     db.close()
     mq.close()
+    wal.close()
 
 
-# Do not register atexit immediately if we plan to use threads that might need the connection
-# or handle it gracefully. For now, we keep it but ensure threads are daemon.
 atexit.register(close_db_connection)
 
 
@@ -240,179 +241,200 @@ def remove_credit_logic(user_id: str, amount: int, transaction_id: str | None = 
 #
 # All three endpoints use WATCH/MULTI/EXEC for optimistic concurrency control.
 
-def _payment_wal_key(order_id: str, user_id: str) -> str:
-    return f"2pc:payment:{order_id}:{user_id}"
-
-
 def _payment_reserved_key(user_id: str) -> str:
     return f"reserved:payment:{user_id}"
 
 def prepare_pay_logic(order_id: str, user_id: str, amount: int):
     """
-    2PC Phase 1 – PREPARE (participant: payment).
+    2PC Phase 1 - PREPARE (participant: payment).
 
-    Atomically checks that user_id has enough unreserved credit, then
-    soft-reserves `amount` and records a WAL entry so the decision
-    survives participant crashes.
+    WAL state read/written in wal-redis (decoupled).
+    Soft-reservation written in db-redis alongside credit balance so it can
+    be checked atomically in a single WATCH/MULTI/EXEC pipeline.
 
-    Idempotent: a duplicate call for the same (order_id, user_id) returns 200.
+    Order of operations:
+      1. Read WAL from wal-redis — idempotency / abort guard.
+      2. Check availability + soft-reserve in db-redis (WATCH/MULTI/EXEC).
+      3. Write WAL_PREPARED to wal-redis.
+    If step 3 fails, the soft-reserve is rolled back so the state remains clean.
     """
     amount = int(amount)
     wal_key      = _payment_wal_key(order_id, user_id)
     reserved_key = _payment_reserved_key(user_id)
 
+    # Step 1: idempotency check via WAL (wal-redis)
     try:
-        with db.pipeline() as pipe:
-            while True:
-                try:
-                    pipe.watch(user_id, reserved_key, wal_key)
-
-                    # ── Idempotency check ──────────────────────────────────
-                    wal_state = pipe.get(wal_key)
-                    if wal_state in (WAL_PREPARED, WAL_COMMITTED):
-                        pipe.unwatch()
-                        return response_success("Prepare: already done")
-                    if wal_state == WAL_ABORTED:
-                        pipe.unwatch()
-                        return response_error(f"Transaction {order_id} already aborted for user {user_id}")
-
-                    # ── Availability check ─────────────────────────────────
-                    raw = pipe.get(user_id)
-                    if not raw:
-                        pipe.unwatch()
-                        return response_error(f"User: {user_id} not found!")
-                    user      = msgpack.decode(raw, type=UserValue)
-                    reserved  = int(pipe.get(reserved_key) or 0)
-                    available = user.credit - reserved
-
-                    if available < amount:
-                        pipe.unwatch()
-                        return response_error(f"Insufficient credit for user {user_id}: "
-                                   f"available={available}, requested={amount}")
-
-                    # ── Atomic soft-reserve + WAL ──────────────────────────
-                    pipe.multi()
-                    pipe.set(reserved_key, reserved + amount)
-                    pipe.set(wal_key, WAL_PREPARED)
-                    pipe.execute()
-                    break
-
-                except redis.WatchError:
-                    continue  # concurrent writer; retry
-
+        wal_state = wal.get(wal_key)
     except redis.exceptions.RedisError:
         return response_error(DB_ERROR_STR, 500)
 
-    app.logger.debug(f"2PC prepare OK  order={order_id} user={user_id} amount={amount}")
+    if wal_state in (WAL_PREPARED, WAL_COMMITTED):
+        return response_success("Prepare: already done")
+    if wal_state == WAL_ABORTED:
+        return response_error(f"Transaction {order_id} already aborted for user {user_id}")
+
+    # Step 2: availability check + soft-reserve (db-redis only, no WAL key in pipeline)
+    for _ in range(10):
+        try:
+            with db.pipeline() as pipe:
+                pipe.watch(user_id, reserved_key)
+                raw = pipe.get(user_id)
+                if not raw:
+                    pipe.unwatch()
+                    return response_error(f"User: {user_id} not found!")
+                user     = msgpack.decode(raw, type=UserValue)
+                reserved = int(pipe.get(reserved_key) or 0)
+                available = user.credit - reserved
+                if available < amount:
+                    pipe.unwatch()
+                    return response_error(
+                        f"Insufficient credit for user {user_id}: "
+                        f"available={available}, requested={amount}")
+                pipe.multi()
+                pipe.set(reserved_key, reserved + amount)
+                pipe.execute()
+                break
+        except redis.WatchError:
+            continue
+        except redis.exceptions.RedisError:
+            return response_error(DB_ERROR_STR, 500)
+    else:
+        return response_error("Conflict: could not prepare after retries")
+
+    # Step 3: write WAL entry (wal-redis)
+    try:
+        wal.set(wal_key, WAL_PREPARED)
+    except redis.exceptions.RedisError:
+        # Roll back the soft-reserve we just applied
+        try:
+            for _ in range(5):
+                try:
+                    with db.pipeline() as pipe:
+                        pipe.watch(reserved_key)
+                        cur = int(pipe.get(reserved_key) or 0)
+                        pipe.multi()
+                        pipe.set(reserved_key, max(0, cur - amount))
+                        pipe.execute()
+                        break
+                except redis.WatchError:
+                    continue
+        except Exception:
+            pass
+        return response_error(DB_ERROR_STR, 500)
+
+    app.logger.debug("2PC prepare OK  order=%s user=%s amount=%s", order_id, user_id, amount)
     return response_success("Prepare: OK")
+
 
 def commit_pay_logic(order_id: str, user_id: str, amount: int):
     """
-    2PC Phase 2 – COMMIT (participant: payment).
+    2PC Phase 2 - COMMIT (participant: payment).
 
-    Permanently deducts `amount` from user credit and releases the soft-
-    reservation.  Safe to call multiple times (idempotent via WAL).
+    WAL state read from wal-redis; credit deduction written to db-redis.
+    WAL_COMMITTED written to wal-redis after the db write succeeds.
     """
     amount = int(amount)
     wal_key      = _payment_wal_key(order_id, user_id)
     reserved_key = _payment_reserved_key(user_id)
 
+    # Idempotency / guard via WAL (wal-redis)
     try:
-        with db.pipeline() as pipe:
-            while True:
-                try:
-                    pipe.watch(user_id, reserved_key, wal_key)
-
-                    wal_state = pipe.get(wal_key)
-                    if wal_state == WAL_COMMITTED:
-                        pipe.unwatch()
-                        return response_success("Commit: already done")
-                    if wal_state == WAL_ABORTED:
-                        pipe.unwatch()
-                        return response_error(f"Cannot commit: transaction {order_id} was aborted for user {user_id}")
-
-                    # WAL_PREPARED (or None on coordinator recovery re-drive)
-                    raw = pipe.get(user_id)
-                    if not raw:
-                        pipe.unwatch()
-                        return response_error(f"User: {user_id} not found!")
-                    user      = msgpack.decode(raw, type=UserValue)
-                    reserved  = int(pipe.get(reserved_key) or 0)
-
-                    new_credit   = user.credit - amount
-                    new_reserved = max(0, reserved - amount)
-
-                    if new_credit < 0:
-                        # The coordinator has already durably logged COMMIT, so
-                        # we must commit regardless.  This path should be
-                        # unreachable now that /pay checks reservations, but if
-                        # something bypassed the reservation, log and proceed.
-                        app.logger.error(
-                            f"2PC commit: credit underflow for user {user_id} order {order_id} "
-                            f"(credit={user.credit}, reserved={reserved}, amount={amount}). "
-                            f"Committing anyway to preserve 2PC durability."
-                        )
-
-                    user.credit = new_credit
-
-                    pipe.multi()
-                    pipe.set(user_id, msgpack.encode(user))
-                    pipe.set(reserved_key, new_reserved)
-                    pipe.set(wal_key, WAL_COMMITTED)
-                    pipe.execute()
-                    break
-
-                except redis.WatchError:
-                    continue
-
+        wal_state = wal.get(wal_key)
     except redis.exceptions.RedisError:
         return response_error(DB_ERROR_STR, 500)
 
-    app.logger.debug(f"2PC commit OK   order={order_id} user={user_id} amount={amount}")
+    if wal_state == WAL_COMMITTED:
+        return response_success("Commit: already done")
+    if wal_state == WAL_ABORTED:
+        return response_error(f"Cannot commit: transaction {order_id} was aborted for user {user_id}")
+
+    # Apply deduction to db-redis (WATCH/MULTI/EXEC, no WAL key in pipeline)
+    for _ in range(10):
+        try:
+            with db.pipeline() as pipe:
+                pipe.watch(user_id, reserved_key)
+                raw = pipe.get(user_id)
+                if not raw:
+                    pipe.unwatch()
+                    return response_error(f"User: {user_id} not found!")
+                user     = msgpack.decode(raw, type=UserValue)
+                reserved = int(pipe.get(reserved_key) or 0)
+                new_credit   = user.credit - amount
+                new_reserved = max(0, reserved - amount)
+                if new_credit < 0:
+                    app.logger.error(
+                        "2PC commit: credit underflow for user %s order %s. "
+                        "Committing anyway to preserve 2PC durability.",
+                        user_id, order_id)
+                user.credit = new_credit
+                pipe.multi()
+                pipe.set(user_id, msgpack.encode(user))
+                pipe.set(reserved_key, new_reserved)
+                pipe.execute()
+                break
+        except redis.WatchError:
+            continue
+        except redis.exceptions.RedisError:
+            return response_error(DB_ERROR_STR, 500)
+    else:
+        return response_error("Conflict: could not commit after retries")
+
+    # Write WAL committed (wal-redis) — non-fatal if it fails
+    try:
+        wal.set(wal_key, WAL_COMMITTED)
+    except redis.exceptions.RedisError:
+        app.logger.warning("Could not write WAL_COMMITTED for order %s user %s; idempotent on retry",
+                           order_id, user_id)
+
+    app.logger.debug("2PC commit OK   order=%s user=%s amount=%s", order_id, user_id, amount)
     return response_success("Commit: OK")
+
 
 def abort_pay_logic(order_id: str, user_id: str, amount: int):
     """
-    2PC Phase 2 – ABORT (participant: payment).
+    2PC Phase 2 - ABORT (participant: payment).
 
-    Releases the soft-reservation without touching actual credit.
-    Safe to call even if prepare was never received (WAL=None → no-op).
-    Idempotent: calling twice returns 200 both times.
+    WAL state read from wal-redis.  If WAL is None or ABORTED → no-op.
+    Reservation release written to db-redis; WAL_ABORTED written to wal-redis.
     """
     amount = int(amount)
     wal_key      = _payment_wal_key(order_id, user_id)
     reserved_key = _payment_reserved_key(user_id)
 
+    # Idempotency / guard via WAL (wal-redis)
     try:
-        with db.pipeline() as pipe:
-            while True:
-                try:
-                    pipe.watch(reserved_key, wal_key)
-
-                    wal_state = pipe.get(wal_key)
-                    if wal_state == WAL_ABORTED or wal_state is None:
-                        # Already aborted or never prepared — nothing to release.
-                        pipe.unwatch()
-                        return response_success("Abort: already done or not prepared")
-                    if wal_state == WAL_COMMITTED:
-                        pipe.unwatch()
-                        return response_error(f"Cannot abort: transaction {order_id} already committed for user {user_id}")
-
-                    # WAL_PREPARED: release the reservation.
-                    reserved     = int(pipe.get(reserved_key) or 0)
-                    new_reserved = max(0, reserved - amount)
-
-                    pipe.multi()
-                    pipe.set(reserved_key, new_reserved)
-                    pipe.set(wal_key, WAL_ABORTED)
-                    pipe.execute()
-                    break
-
-                except redis.WatchError:
-                    continue
-
+        wal_state = wal.get(wal_key)
     except redis.exceptions.RedisError:
         return response_error(DB_ERROR_STR, 500)
+
+    if wal_state == WAL_ABORTED or wal_state is None:
+        return response_success("Abort: already done or not prepared")
+    if wal_state == WAL_COMMITTED:
+        return response_error(f"Cannot abort: transaction {order_id} already committed for user {user_id}")
+
+    # Release reservation in db-redis (no WAL key in pipeline)
+    for _ in range(10):
+        try:
+            with db.pipeline() as pipe:
+                pipe.watch(reserved_key)
+                reserved     = int(pipe.get(reserved_key) or 0)
+                new_reserved = max(0, reserved - amount)
+                pipe.multi()
+                pipe.set(reserved_key, new_reserved)
+                pipe.execute()
+                break
+        except redis.WatchError:
+            continue
+        except redis.exceptions.RedisError:
+            return response_error(DB_ERROR_STR, 500)
+    else:
+        return response_error("Conflict: could not abort after retries")
+
+    # Write WAL aborted (wal-redis)
+    try:
+        wal.set(wal_key, WAL_ABORTED)
+    except redis.exceptions.RedisError:
+        app.logger.warning("Could not write WAL_ABORTED for order %s user %s", order_id, user_id)
 
     return response_success("Abort: OK")
 

--- a/payment/wal.py
+++ b/payment/wal.py
@@ -1,0 +1,58 @@
+"""
+wal.py — Decoupled Write-Ahead Log connection for the payment service.
+
+WAL entries stored here:
+  wal:payment:2pc:{order_id}:{user_id}  → bytes  (prepared/committed/aborted)
+
+Soft-reservation counters (reserved:payment:{user_id}) remain in the main
+db-redis because they are operational state checked atomically alongside
+the credit balance in the same WATCH/MULTI/EXEC pipeline.
+"""
+
+import os
+import redis
+from redis.retry import Retry
+from redis.backoff import NoBackoff
+
+
+def _payment_wal_key(order_id: str, user_id: str) -> str:
+    return f"wal:payment:2pc:{order_id}:{user_id}"
+
+
+def _build_wal_connection() -> redis.Redis:
+    password = os.environ.get('WAL_REDIS_PASSWORD', '')
+    db_num   = int(os.environ.get('WAL_REDIS_DB', '0'))
+    sentinel = os.environ.get('WAL_SENTINEL_HOSTS', '')
+    name     = os.environ.get('WAL_MASTER_NAME', 'wal-master')
+
+    if sentinel:
+        from redis.sentinel import Sentinel as _Sentinel
+        peers = [(h.split(':')[0], int(h.split(':')[1]))
+                 for h in sentinel.split(',')]
+        return _Sentinel(
+            peers,
+            password=password,
+            db=db_num,
+            socket_timeout=1.5,
+            socket_connect_timeout=1.5,
+        ).master_for(
+            name,
+            socket_timeout=1.5,
+            socket_connect_timeout=1.5,
+            retry=Retry(NoBackoff(), 3),
+            retry_on_error=[
+                redis.exceptions.ConnectionError,
+                redis.exceptions.TimeoutError,
+                redis.exceptions.ReadOnlyError,
+            ],
+        )
+
+    return redis.Redis(
+        host=os.environ['WAL_REDIS_HOST'],
+        port=int(os.environ['WAL_REDIS_PORT']),
+        password=password,
+        db=db_num,
+    )
+
+
+wal: redis.Redis = _build_wal_connection()

--- a/stock/app.py
+++ b/stock/app.py
@@ -11,10 +11,11 @@ import redis
 from msgspec import msgpack, Struct
 from flask import Flask, jsonify, abort, Response
 
+from wal import wal, _stock_wal_key
 
 DB_ERROR_STR = "DB error"
 
-# 2PC WAL state values stored in Redis
+# 2PC WAL state values stored in wal-redis (decoupled from business data)
 WAL_PREPARED  = b"prepared"
 WAL_COMMITTED = b"committed"
 WAL_ABORTED   = b"aborted"
@@ -66,10 +67,9 @@ mq: redis.Redis = redis.Redis(host=os.environ['MQ_REDIS_HOST'],
 def close_db_connection():
     db.close()
     mq.close()
+    wal.close()
 
 
-# Do not register atexit immediately if we plan to use threads that might need the connection
-# or handle it gracefully. For now, we keep it but ensure threads are daemon.
 atexit.register(close_db_connection)
 
 
@@ -326,16 +326,15 @@ def subtract_stock_batch_logic(items_json: str, transaction_id: str | None = Non
 # All three endpoints use WATCH/MULTI/EXEC for optimistic concurrency control so
 # multiple gunicorn workers never corrupt each other's reads and writes.
 
-def _stock_wal_key(order_id: str) -> str:
-    return f"2pc:stock:{order_id}"
-
 def _stock_reserved_key(item_id: str) -> str:
     return f"reserved:stock:{item_id}"
 
 def prepare_subtract_batch_logic(order_id: str, items_json: str):
     """
-    2PC Phase 1 – PREPARE BATCH (participant: stock).
-    Atomically checks availability and reserves stock for all items in the batch.
+    2PC Phase 1 - PREPARE BATCH (participant: stock).
+    WAL state (prepared/committed/aborted) lives in the decoupled wal-redis.
+    Soft-reservations stay in db-redis alongside stock values so they can
+    be checked atomically in a single WATCH/MULTI/EXEC pipeline.
     """
     try:
         items: dict[str, int] = json.loads(items_json)
@@ -346,27 +345,25 @@ def prepare_subtract_batch_logic(order_id: str, items_json: str):
     wal_key = _stock_wal_key(order_id)
     reserved_keys = {k: _stock_reserved_key(k) for k in keys}
 
-    # Watch all involved keys
-    watch_keys = keys + list(reserved_keys.values()) + [wal_key]
+    # ── Step 1: Idempotency check via WAL (wal-redis) ──────────────────────
+    try:
+        wal_state = wal.get(wal_key)
+    except redis.exceptions.RedisError:
+        return response_error(DB_ERROR_STR, 500)
+
+    if wal_state == WAL_ABORTED:
+        return response_error(f"Transaction {order_id} already aborted")
+    if wal_state in (WAL_PREPARED, WAL_COMMITTED):
+        return response_success("Prepare batch: already done")
+
+    # ── Step 2: Availability check + soft-reserve (db-redis) ──────────────
+    watch_keys = keys + list(reserved_keys.values())
 
     for _ in range(10):
         try:
             with db.pipeline() as pipe:
                 pipe.watch(*watch_keys)
 
-                # ── Idempotency check ──────────────────────────────────
-                # If all are already prepared/committed, return success.
-                # If any is aborted, fail.
-                wal_state = pipe.get(wal_key)
-                if wal_state == WAL_ABORTED:
-                    pipe.unwatch()
-                    return response_error(f"Transaction {order_id} already aborted")
-
-                if wal_state in (WAL_PREPARED, WAL_COMMITTED):
-                    pipe.unwatch()
-                    return response_success("Prepare batch: already done")
-
-                # ── Availability check ─────────────────────────────────
                 current_reserved = {}
                 for k, amount in items.items():
                     raw = pipe.get(k)
@@ -382,22 +379,40 @@ def prepare_subtract_batch_logic(order_id: str, items_json: str):
                         pipe.unwatch()
                         return response_error(f"Insufficient stock for item {k}")
 
-                # ── Atomic soft-reserve + WAL ──────────────────────────
                 pipe.multi()
                 for k, amount in items.items():
                     pipe.set(reserved_keys[k], current_reserved[k] + int(amount))
-                pipe.set(wal_key, WAL_PREPARED)
                 pipe.execute()
-                return response_success("Prepare batch: OK")
+                break  # soft-reserve committed to db-redis
         except redis.WatchError:
             continue
         except redis.exceptions.RedisError:
             return response_error(DB_ERROR_STR, 500)
-    return response_error("Conflict: could not prepare batch after retries")
+    else:
+        return response_error("Conflict: could not prepare batch after retries")
+
+    # ── Step 3: Write WAL entry (wal-redis) ────────────────────────────────
+    try:
+        wal.set(wal_key, WAL_PREPARED)
+    except redis.exceptions.RedisError:
+        # WAL write failed — roll back the soft-reserve we just applied
+        try:
+            with db.pipeline(transaction=True) as pipe:
+                pipe.multi()
+                for k, amount in items.items():
+                    reserved = int(db.get(reserved_keys[k]) or 0)
+                    pipe.set(reserved_keys[k], max(0, reserved - int(amount)))
+                pipe.execute()
+        except Exception:
+            pass
+        return response_error(DB_ERROR_STR, 500)
+
+    return response_success("Prepare batch: OK")
 
 def commit_subtract_batch_logic(order_id: str, items_json: str):
     """
-    2PC Phase 2 – COMMIT BATCH (participant: stock).
+    2PC Phase 2 - COMMIT BATCH (participant: stock).
+    WAL state read from wal-redis; stock deductions written to db-redis.
     """
     try:
         items: dict[str, int] = json.loads(items_json)
@@ -407,25 +422,26 @@ def commit_subtract_batch_logic(order_id: str, items_json: str):
     keys = list(items.keys())
     wal_key = _stock_wal_key(order_id)
     reserved_keys = {k: _stock_reserved_key(k) for k in keys}
-    watch_keys = keys + list(reserved_keys.values()) + [wal_key]
 
+    # Idempotency check via WAL (wal-redis)
+    try:
+        wal_state = wal.get(wal_key)
+    except redis.exceptions.RedisError:
+        return response_error(DB_ERROR_STR, 500)
+
+    if wal_state == WAL_ABORTED:
+        return response_error(f"Cannot commit: transaction {order_id} aborted")
+    if wal_state == WAL_COMMITTED:
+        return response_success("Commit batch: already done")
+
+    # Apply deductions to db-redis
+    watch_keys = keys + list(reserved_keys.values())
     for _ in range(10):
         try:
             with db.pipeline() as pipe:
                 pipe.watch(*watch_keys)
-
-                wal_state = pipe.get(wal_key)
-                if wal_state == WAL_ABORTED:
-                    pipe.unwatch()
-                    return response_error(f"Cannot commit: transaction {order_id} aborted")
-
-                if wal_state == WAL_COMMITTED:
-                    pipe.unwatch()
-                    return response_success("Commit batch: already done")
-
                 current_reserved = {}
                 current_values = {}
-
                 for k, amount in items.items():
                     raw = pipe.get(k)
                     if not raw:
@@ -434,37 +450,39 @@ def commit_subtract_batch_logic(order_id: str, items_json: str):
                     current_values[k] = msgpack.decode(raw, type=StockValue)
                     res_val = pipe.get(reserved_keys[k])
                     current_reserved[k] = int(res_val or 0)
-
                 pipe.multi()
                 for k, amount in items.items():
                     item = current_values[k]
                     item.stock -= int(amount)
                     if item.stock < 0:
-                        # The coordinator has already durably logged COMMIT, so
-                        # we must commit regardless.  This path should be
-                        # unreachable, but if
-                        # something bypassed the reservation, log and proceed.
                         app.logger.error(
-                            f"2PC commit: stock underflow for item {k} order {order_id} "
-                            f"(stock={item.stock}, reserved={current_reserved[k]}, amount={amount}). "
+                            f"2PC commit: stock underflow for item {k} order {order_id}. "
                             f"Committing anyway to preserve 2PC durability."
                         )
                     new_reserved = max(0, current_reserved[k] - int(amount))
-
                     pipe.set(k, msgpack.encode(item))
                     pipe.set(reserved_keys[k], new_reserved)
-                pipe.set(wal_key, WAL_COMMITTED)
                 pipe.execute()
-                return response_success("Commit batch: OK")
+                break
         except redis.WatchError:
             continue
         except redis.exceptions.RedisError:
             return response_error(DB_ERROR_STR, 500)
-    return response_error("Conflict: could not commit batch after retries")
+    else:
+        return response_error("Conflict: could not commit batch after retries")
+
+    # Write WAL committed (wal-redis) — non-fatal if it fails
+    try:
+        wal.set(wal_key, WAL_COMMITTED)
+    except redis.exceptions.RedisError:
+        app.logger.warning("Could not write WAL_COMMITTED for order %s; idempotent on retry", order_id)
+
+    return response_success("Commit batch: OK")
 
 def abort_subtract_batch_logic(order_id: str, items_json: str):
     """
-    2PC Phase 2 – ABORT BATCH (participant: stock).
+    2PC Phase 2 - ABORT BATCH (participant: stock).
+    WAL state read/written in wal-redis; reservation release in db-redis.
     """
     try:
         items: dict[str, int] = json.loads(items_json)
@@ -474,38 +492,52 @@ def abort_subtract_batch_logic(order_id: str, items_json: str):
     keys = list(items.keys())
     wal_key = _stock_wal_key(order_id)
     reserved_keys = {k: _stock_reserved_key(k) for k in keys}
-    watch_keys = list(reserved_keys.values()) + [wal_key]
 
+    # Idempotency check via WAL (wal-redis)
+    try:
+        wal_state = wal.get(wal_key)
+    except redis.exceptions.RedisError:
+        return response_error(DB_ERROR_STR, 500)
+
+    if wal_state == WAL_COMMITTED:
+        return response_error(f"Cannot abort: transaction {order_id}, already committed")
+    if wal_state == WAL_ABORTED:
+        return response_success("Abort batch: already done")
+
+    # Release reservations in db-redis
+    watch_keys = list(reserved_keys.values())
     for _ in range(10):
         try:
             with db.pipeline() as pipe:
                 pipe.watch(*watch_keys)
-
-                wal_state = pipe.get(wal_key)
-                if wal_state == WAL_COMMITTED:
-                    pipe.unwatch()
-                    return response_error(f"Cannot abort: transaction {order_id}, already committed")
-                elif wal_state != WAL_ABORTED:
-                    current_reserved = {}
-                    for k, amount in items.items():
-                        raw = pipe.get(k)
-                        if not raw:
-                            pipe.unwatch()
-                            return response_error(f"Item: {k} not found!")
-                        res_val = pipe.get(reserved_keys[k])
-                        current_reserved[k] = int(res_val or 0)
-                    pipe.multi()
-                    pipe.set(wal_key, WAL_ABORTED)
-                    for k, amount in items.items():
-                        new_reserved = max(0, current_reserved[k] - int(amount))
-                        pipe.set(reserved_keys[k], new_reserved)
-                    pipe.execute()
-                return response_success("Abort batch: OK")
+                current_reserved = {}
+                for k, amount in items.items():
+                    raw = pipe.get(k)
+                    if not raw:
+                        pipe.unwatch()
+                        return response_error(f"Item: {k} not found!")
+                    res_val = pipe.get(reserved_keys[k])
+                    current_reserved[k] = int(res_val or 0)
+                pipe.multi()
+                for k, amount in items.items():
+                    new_reserved = max(0, current_reserved[k] - int(amount))
+                    pipe.set(reserved_keys[k], new_reserved)
+                pipe.execute()
+                break
         except redis.WatchError:
             continue
         except redis.exceptions.RedisError:
             return response_error(DB_ERROR_STR, 500)
-    return response_error("Conflict: could not abort batch after retries")
+    else:
+        return response_error("Conflict: could not abort batch after retries")
+
+    # Write WAL aborted (wal-redis)
+    try:
+        wal.set(wal_key, WAL_ABORTED)
+    except redis.exceptions.RedisError:
+        app.logger.warning("Could not write WAL_ABORTED for order %s", order_id)
+
+    return response_success("Abort batch: OK")
 
 # ─── Flask Routes (Wrappers) ──────────────────────────────────────────────────
 

--- a/stock/app.py
+++ b/stock/app.py
@@ -395,16 +395,23 @@ def prepare_subtract_batch_logic(order_id: str, items_json: str):
     try:
         wal.set(wal_key, WAL_PREPARED)
     except redis.exceptions.RedisError:
-        # WAL write failed — roll back the soft-reserve we just applied
-        try:
-            with db.pipeline(transaction=True) as pipe:
-                pipe.multi()
-                for k, amount in items.items():
-                    reserved = int(db.get(reserved_keys[k]) or 0)
-                    pipe.set(reserved_keys[k], max(0, reserved - int(amount)))
-                pipe.execute()
-        except Exception:
-            pass
+        # WAL write failed — roll back the soft-reserve we just applied.
+        # Use a proper WATCH/MULTI/EXEC so the rollback is atomic and another
+        # writer cannot corrupt the reservation counter between our read and write.
+        for _ in range(5):
+            try:
+                with db.pipeline() as pipe:
+                    pipe.watch(*reserved_keys.values())
+                    current = {k: int(pipe.get(reserved_keys[k]) or 0) for k in items}
+                    pipe.multi()
+                    for k, amount in items.items():
+                        pipe.set(reserved_keys[k], max(0, current[k] - int(amount)))
+                    pipe.execute()
+                    break
+            except redis.WatchError:
+                continue
+            except Exception:
+                break
         return response_error(DB_ERROR_STR, 500)
 
     return response_success("Prepare batch: OK")

--- a/stock/wal.py
+++ b/stock/wal.py
@@ -1,0 +1,59 @@
+"""
+wal.py — Decoupled Write-Ahead Log connection for the stock service.
+
+WAL entries stored here:
+  wal:stock:2pc:{order_id}              → bytes  (prepared/committed/aborted)
+
+Soft-reservation counters (reserved:stock:{item_id}) remain in the main
+db-redis because they are *operational state* — they must be checked
+atomically alongside the actual stock value in the same WATCH/MULTI/EXEC
+pipeline. True WAL entries (transaction state machines) are separated.
+"""
+
+import os
+import redis
+from redis.retry import Retry
+from redis.backoff import NoBackoff
+
+
+def _stock_wal_key(order_id: str) -> str:
+    return f"wal:stock:2pc:{order_id}"
+
+
+def _build_wal_connection() -> redis.Redis:
+    password = os.environ.get('WAL_REDIS_PASSWORD', '')
+    db_num   = int(os.environ.get('WAL_REDIS_DB', '0'))
+    sentinel = os.environ.get('WAL_SENTINEL_HOSTS', '')
+    name     = os.environ.get('WAL_MASTER_NAME', 'wal-master')
+
+    if sentinel:
+        from redis.sentinel import Sentinel as _Sentinel
+        peers = [(h.split(':')[0], int(h.split(':')[1]))
+                 for h in sentinel.split(',')]
+        return _Sentinel(
+            peers,
+            password=password,
+            db=db_num,
+            socket_timeout=1.5,
+            socket_connect_timeout=1.5,
+        ).master_for(
+            name,
+            socket_timeout=1.5,
+            socket_connect_timeout=1.5,
+            retry=Retry(NoBackoff(), 3),
+            retry_on_error=[
+                redis.exceptions.ConnectionError,
+                redis.exceptions.TimeoutError,
+                redis.exceptions.ReadOnlyError,
+            ],
+        )
+
+    return redis.Redis(
+        host=os.environ['WAL_REDIS_HOST'],
+        port=int(os.environ['WAL_REDIS_PORT']),
+        password=password,
+        db=db_num,
+    )
+
+
+wal: redis.Redis = _build_wal_connection()

--- a/test-scripts/14_wal_decoupled.sh
+++ b/test-scripts/14_wal_decoupled.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+# Test 14: Decoupled WAL — verify WAL entries live in wal-redis, not in
+# business-data Redis, and survive killing the business-data container.
+#
+# What this proves:
+#   1. After a checkout, WAL keys exist in wal-redis (wal:order:*, wal:stock:*,
+#      wal:payment:*)  and are ABSENT from order-redis, stock-redis, payment-redis.
+#   2. Killing order-redis-master does NOT destroy the WAL — wal-redis still
+#      holds all entries, so recovery can resume without data loss.
+#   3. After order-redis-master restarts, a fresh checkout succeeds, confirming
+#      the whole stack (including WAL recovery) is working again.
+#
+# Only runs in DEPLOY_MODE=docker (direct container control required).
+source "$(dirname "$0")/helpers.sh"
+
+header "TEST 14 — Decoupled WAL: WAL entries survive business-data Redis loss"
+
+if [ "${DEPLOY_MODE:-docker}" != "docker" ]; then
+  yellow "Skipping: DEPLOY_MODE=${DEPLOY_MODE:-docker} (requires docker)"
+  exit 0
+fi
+
+WAL_CLI="docker compose exec -T wal-redis-master redis-cli -a redis --no-auth-warning"
+ORDER_CLI="docker compose exec -T order-redis-master redis-cli -a redis --no-auth-warning"
+STOCK_CLI="docker compose exec -T stock-redis-master redis-cli -a redis --no-auth-warning"
+PAYMENT_CLI="docker compose exec -T payment-redis-master redis-cli -a redis --no-auth-warning"
+
+seed_data
+
+# ── Part A: WAL entries land in wal-redis, not in business-data Redis ────────
+
+header "Part A — WAL key placement"
+
+USER_ID=$(create_funded_user 500)
+ORDER_ID=$(create_order_with_item "$USER_ID" 0 1)
+
+# Use 2PC mode so participant WAL entries (stock + payment) are written
+CODE=$(post "/orders/mode/2pc")
+assert_http "Switch to 2PC mode" "200" "$CODE"
+
+CODE=$(post "/orders/checkout/$ORDER_ID")
+assert_http "2PC checkout returns 200" "200" "$CODE"
+
+yellow "Checking wal-redis for WAL keys..."
+WAL_KEYS=$($WAL_CLI keys "wal:*" 2>/dev/null | tr '\r\n' ' ')
+yellow "wal-redis keys: $WAL_KEYS"
+
+# There should be at least one wal: key (saga/2pc pending sets or tx states)
+if echo "$WAL_KEYS" | grep -q "wal:"; then
+  green "WAL keys found in wal-redis: PASS"
+  PASS=$((PASS+1))
+else
+  red "No wal: keys found in wal-redis"
+  FAIL=$((FAIL+1))
+fi
+
+yellow "Confirming WAL keys are ABSENT from order-redis..."
+ORDER_WAL=$($ORDER_CLI keys "wal:*" 2>/dev/null | grep -v "^$" | head -5)
+if [ -z "$ORDER_WAL" ]; then
+  green "order-redis has no wal: keys — correctly separated: PASS"
+  PASS=$((PASS+1))
+else
+  red "order-redis unexpectedly contains wal: keys: $ORDER_WAL"
+  FAIL=$((FAIL+1))
+fi
+
+yellow "Confirming old-style WAL keys (2pc:pending, saga:pending) absent from order-redis..."
+OLD_WAL=$($ORDER_CLI keys "2pc:pending" 2>/dev/null; $ORDER_CLI keys "saga:pending" 2>/dev/null)
+OLD_WAL=$(echo "$OLD_WAL" | grep -v "^$" | head -5)
+if [ -z "$OLD_WAL" ]; then
+  green "order-redis has no legacy WAL keys — fully migrated: PASS"
+  PASS=$((PASS+1))
+else
+  red "order-redis still has legacy WAL keys: $OLD_WAL"
+  FAIL=$((FAIL+1))
+fi
+
+yellow "Confirming 2PC WAL keys absent from stock-redis..."
+STOCK_WAL=$($STOCK_CLI keys "wal:*" 2>/dev/null; $STOCK_CLI keys "2pc:stock:*" 2>/dev/null)
+STOCK_WAL=$(echo "$STOCK_WAL" | grep -v "^$" | head -5)
+if [ -z "$STOCK_WAL" ]; then
+  green "stock-redis has no WAL keys — correctly separated: PASS"
+  PASS=$((PASS+1))
+else
+  red "stock-redis unexpectedly contains WAL keys: $STOCK_WAL"
+  FAIL=$((FAIL+1))
+fi
+
+yellow "Confirming 2PC WAL keys absent from payment-redis..."
+PAYMENT_WAL=$($PAYMENT_CLI keys "wal:*" 2>/dev/null; $PAYMENT_CLI keys "2pc:payment:*" 2>/dev/null)
+PAYMENT_WAL=$(echo "$PAYMENT_WAL" | grep -v "^$" | head -5)
+if [ -z "$PAYMENT_WAL" ]; then
+  green "payment-redis has no WAL keys — correctly separated: PASS"
+  PASS=$((PASS+1))
+else
+  red "payment-redis unexpectedly contains WAL keys: $PAYMENT_WAL"
+  FAIL=$((FAIL+1))
+fi
+
+# ── Part B: WAL survives order-redis dying ────────────────────────────────────
+
+header "Part B — WAL survives order-redis-master crash"
+
+# Start a checkout in saga mode, capture its WAL entry before any crash
+CODE=$(post "/orders/mode/saga")
+assert_http "Switch back to saga mode" "200" "$CODE"
+
+USER2=$(create_funded_user 500)
+ORDER2=$(create_order_with_item "$USER2" 0 1)
+CODE=$(post "/orders/checkout/$ORDER2")
+assert_http "Saga checkout succeeds before crash" "200" "$CODE"
+
+yellow "Snapshotting WAL keys before crash..."
+WAL_BEFORE=$($WAL_CLI keys "wal:*" 2>/dev/null | sort | tr '\r\n' '|')
+yellow "WAL before: $WAL_BEFORE"
+
+yellow "Killing order-redis-master..."
+docker compose stop order-redis-master > /dev/null 2>&1
+
+yellow "Confirming wal-redis still readable after order-redis dies..."
+WAL_AFTER=$($WAL_CLI keys "wal:*" 2>/dev/null | sort | tr '\r\n' '|')
+yellow "WAL after crash: $WAL_AFTER"
+
+if [ -n "$WAL_AFTER" ]; then
+  green "wal-redis readable after order-redis crash: PASS"
+  PASS=$((PASS+1))
+else
+  yellow "wal-redis returned no keys (may be empty if WAL was cleaned up — checking ping)"
+  PING=$($WAL_CLI ping 2>/dev/null)
+  if [ "$PING" = "PONG" ]; then
+    green "wal-redis still reachable (WAL keys already cleaned on success): PASS"
+    PASS=$((PASS+1))
+  else
+    red "wal-redis unreachable after order-redis crash"
+    FAIL=$((FAIL+1))
+  fi
+fi
+
+yellow "Restarting order-redis-master..."
+docker compose start order-redis-master > /dev/null 2>&1
+
+yellow "Waiting for order-redis to recover..."
+for i in $(seq 1 20); do
+  PING=$($ORDER_CLI ping 2>/dev/null)
+  [ "$PING" = "PONG" ] && green "order-redis-master recovered" && break
+  [ "$i" -eq 20 ] && red "order-redis did not recover in time" && FAIL=$((FAIL+1))
+  sleep 2
+done
+
+# Wait for services to reconnect
+sleep 5
+
+# ── Part C: System works after recovery ───────────────────────────────────────
+
+header "Part C — Full checkout works after recovery"
+
+USER3=$(create_funded_user 500)
+ORDER3=$(create_order_with_item "$USER3" 0 1)
+CODE=$(post "/orders/checkout/$ORDER3")
+assert_http "Checkout succeeds after order-redis recovery" "200" "$CODE"
+
+STATUS=$(json_field "$(get_body /orders/find/$ORDER3)" "status")
+assert_eq "Order marked paid after recovery" "paid" "$STATUS"
+
+# Switch back to saga for subsequent tests
+post "/orders/mode/saga" > /dev/null 2>&1
+
+summary
+
+# ── Part D: Orchestrator WAL in wal-redis ────────────────────────────────────
+
+header "Part D — Orchestrator WAL entries in wal-redis"
+
+yellow "Checking wal-redis for orchestrator WAL keys after checkout..."
+ORCH_WAL_KEYS=$($WAL_CLI keys "wal:orch:*" 2>/dev/null | tr '\r\n' ' ')
+yellow "wal:orch:* keys found: ${ORCH_WAL_KEYS:-<none — completed batches cleaned up>}"
+
+# wal:orch:batch:* keys may have been cleaned up if the checkout completed
+# normally (complete_batch sets a 24h TTL and removes from pending).
+# So we check that wal-redis is responsive and that no orch WAL keys live
+# in mq-redis (where they must not be).
+MQ_CLI="docker compose exec -T mq-redis redis-cli -a redis --no-auth-warning"
+
+MISPLACED=$($MQ_CLI keys "wal:orch:*" 2>/dev/null | grep -v "^$" | head -5)
+if [ -z "$MISPLACED" ]; then
+  green "mq-redis has no wal:orch: keys — orchestrator WAL correctly in wal-redis: PASS"
+  PASS=$((PASS+1))
+else
+  red "mq-redis unexpectedly contains wal:orch: keys: $MISPLACED"
+  FAIL=$((FAIL+1))
+fi
+
+yellow "Killing BOTH orchestrator containers to test WAL survives..."
+docker compose stop orchestrator-1 orchestrator-2 > /dev/null 2>&1
+
+yellow "Verifying wal-redis still reachable while orchestrators are down..."
+PING=$($WAL_CLI ping 2>/dev/null)
+if [ "$PING" = "PONG" ]; then
+  green "wal-redis alive with orchestrators stopped: PASS"
+  PASS=$((PASS+1))
+else
+  red "wal-redis unreachable after stopping orchestrators"
+  FAIL=$((FAIL+1))
+fi
+
+yellow "Restarting orchestrators..."
+docker compose start orchestrator-1 orchestrator-2 > /dev/null 2>&1
+
+# Wait for orchestrators to come back up and run recovery
+sleep 8
+
+yellow "Verifying checkout works after orchestrator restart (recovery ran)..."
+USER4=$(create_funded_user 500)
+ORDER4=$(create_order_with_item "$USER4" 0 1)
+CODE=$(post "/orders/checkout/$ORDER4")
+assert_http "Checkout succeeds after orchestrator restart" "200" "$CODE"
+
+STATUS=$(json_field "$(get_body /orders/find/$ORDER4)" "status")
+assert_eq "Order paid after orchestrator restart" "paid" "$STATUS"
+
+summary

--- a/test-scripts/14_wal_decoupled.sh
+++ b/test-scripts/14_wal_decoupled.sh
@@ -3,12 +3,18 @@
 # business-data Redis, and survive killing the business-data container.
 #
 # What this proves:
-#   1. After a checkout, WAL keys exist in wal-redis (wal:order:*, wal:stock:*,
-#      wal:payment:*)  and are ABSENT from order-redis, stock-redis, payment-redis.
+#   1. After a checkout, NEW WAL keys appear only in wal-redis, not in
+#      order-redis, stock-redis, or payment-redis.
 #   2. Killing order-redis-master does NOT destroy the WAL — wal-redis still
 #      holds all entries, so recovery can resume without data loss.
 #   3. After order-redis-master restarts, a fresh checkout succeeds, confirming
 #      the whole stack (including WAL recovery) is working again.
+#
+# NOTE: This test uses a delta approach for key-placement checks. It snapshots
+# keys in each business-data Redis BEFORE the checkout, runs the checkout, then
+# asserts no NEW WAL-format keys were added. This makes the test robust against
+# leftover keys from previous runs (e.g. when volumes were not wiped between
+# deployments). For a fully clean run: docker compose down -v && up --build.
 #
 # Only runs in DEPLOY_MODE=docker (direct container control required).
 source "$(dirname "$0")/helpers.sh"
@@ -38,14 +44,22 @@ ORDER_ID=$(create_order_with_item "$USER_ID" 0 1)
 CODE=$(post "/orders/mode/2pc")
 assert_http "Switch to 2PC mode" "200" "$CODE"
 
+# ── Snapshot keys in each business-data Redis BEFORE the checkout ─────────────
+# We diff before/after so leftover keys from prior runs don't cause false fails.
+ORDER_BEFORE=$($ORDER_CLI keys "wal:*"       2>/dev/null | sort)
+STOCK_BEFORE_WAL=$($STOCK_CLI keys "wal:*"        2>/dev/null | sort)
+STOCK_BEFORE_OLD=$($STOCK_CLI keys "2pc:stock:*"  2>/dev/null | sort)
+PAY_BEFORE_WAL=$($PAYMENT_CLI keys "wal:*"          2>/dev/null | sort)
+PAY_BEFORE_OLD=$($PAYMENT_CLI keys "2pc:payment:*"  2>/dev/null | sort)
+
 CODE=$(post "/orders/checkout/$ORDER_ID")
 assert_http "2PC checkout returns 200" "200" "$CODE"
 
+# ── Check wal-redis received entries ──────────────────────────────────────────
 yellow "Checking wal-redis for WAL keys..."
 WAL_KEYS=$($WAL_CLI keys "wal:*" 2>/dev/null | tr '\r\n' ' ')
 yellow "wal-redis keys: $WAL_KEYS"
 
-# There should be at least one wal: key (saga/2pc pending sets or tx states)
 if echo "$WAL_KEYS" | grep -q "wal:"; then
   green "WAL keys found in wal-redis: PASS"
   PASS=$((PASS+1))
@@ -54,13 +68,15 @@ else
   FAIL=$((FAIL+1))
 fi
 
+# ── Check order-redis received no new wal: keys ───────────────────────────────
 yellow "Confirming WAL keys are ABSENT from order-redis..."
-ORDER_WAL=$($ORDER_CLI keys "wal:*" 2>/dev/null | grep -v "^$" | head -5)
-if [ -z "$ORDER_WAL" ]; then
-  green "order-redis has no wal: keys — correctly separated: PASS"
+ORDER_AFTER=$($ORDER_CLI keys "wal:*" 2>/dev/null | sort)
+ORDER_NEW=$(comm -13 <(echo "$ORDER_BEFORE") <(echo "$ORDER_AFTER") | grep -v "^$")
+if [ -z "$ORDER_NEW" ]; then
+  green "order-redis gained no wal: keys — correctly separated: PASS"
   PASS=$((PASS+1))
 else
-  red "order-redis unexpectedly contains wal: keys: $ORDER_WAL"
+  red "order-redis gained new wal: keys during checkout: $ORDER_NEW"
   FAIL=$((FAIL+1))
 fi
 
@@ -75,25 +91,33 @@ else
   FAIL=$((FAIL+1))
 fi
 
-yellow "Confirming 2PC WAL keys absent from stock-redis..."
-STOCK_WAL=$($STOCK_CLI keys "wal:*" 2>/dev/null; $STOCK_CLI keys "2pc:stock:*" 2>/dev/null)
-STOCK_WAL=$(echo "$STOCK_WAL" | grep -v "^$" | head -5)
-if [ -z "$STOCK_WAL" ]; then
-  green "stock-redis has no WAL keys — correctly separated: PASS"
+# ── Check stock-redis received no new WAL keys ────────────────────────────────
+yellow "Confirming no new 2PC WAL keys written to stock-redis during checkout..."
+STOCK_AFTER_WAL=$($STOCK_CLI keys "wal:*"       2>/dev/null | sort)
+STOCK_AFTER_OLD=$($STOCK_CLI keys "2pc:stock:*" 2>/dev/null | sort)
+STOCK_NEW_WAL=$(comm -13 <(echo "$STOCK_BEFORE_WAL") <(echo "$STOCK_AFTER_WAL") | grep -v "^$")
+STOCK_NEW_OLD=$(comm -13 <(echo "$STOCK_BEFORE_OLD") <(echo "$STOCK_AFTER_OLD") | grep -v "^$")
+STOCK_NEW=$(printf "%s\n%s" "$STOCK_NEW_WAL" "$STOCK_NEW_OLD" | grep -v "^$")
+if [ -z "$STOCK_NEW" ]; then
+  green "stock-redis gained no WAL keys during checkout — correctly separated: PASS"
   PASS=$((PASS+1))
 else
-  red "stock-redis unexpectedly contains WAL keys: $STOCK_WAL"
+  red "stock-redis gained new WAL keys during checkout (expected only in wal-redis): $STOCK_NEW"
   FAIL=$((FAIL+1))
 fi
 
-yellow "Confirming 2PC WAL keys absent from payment-redis..."
-PAYMENT_WAL=$($PAYMENT_CLI keys "wal:*" 2>/dev/null; $PAYMENT_CLI keys "2pc:payment:*" 2>/dev/null)
-PAYMENT_WAL=$(echo "$PAYMENT_WAL" | grep -v "^$" | head -5)
-if [ -z "$PAYMENT_WAL" ]; then
-  green "payment-redis has no WAL keys — correctly separated: PASS"
+# ── Check payment-redis received no new WAL keys ──────────────────────────────
+yellow "Confirming no new 2PC WAL keys written to payment-redis during checkout..."
+PAY_AFTER_WAL=$($PAYMENT_CLI keys "wal:*"          2>/dev/null | sort)
+PAY_AFTER_OLD=$($PAYMENT_CLI keys "2pc:payment:*"  2>/dev/null | sort)
+PAY_NEW_WAL=$(comm -13 <(echo "$PAY_BEFORE_WAL") <(echo "$PAY_AFTER_WAL") | grep -v "^$")
+PAY_NEW_OLD=$(comm -13 <(echo "$PAY_BEFORE_OLD") <(echo "$PAY_AFTER_OLD") | grep -v "^$")
+PAY_NEW=$(printf "%s\n%s" "$PAY_NEW_WAL" "$PAY_NEW_OLD" | grep -v "^$")
+if [ -z "$PAY_NEW" ]; then
+  green "payment-redis gained no WAL keys during checkout — correctly separated: PASS"
   PASS=$((PASS+1))
 else
-  red "payment-redis unexpectedly contains WAL keys: $PAYMENT_WAL"
+  red "payment-redis gained new WAL keys during checkout (expected only in wal-redis): $PAY_NEW"
   FAIL=$((FAIL+1))
 fi
 
@@ -101,7 +125,6 @@ fi
 
 header "Part B — WAL survives order-redis-master crash"
 
-# Start a checkout in saga mode, capture its WAL entry before any crash
 CODE=$(post "/orders/mode/saga")
 assert_http "Switch back to saga mode" "200" "$CODE"
 
@@ -147,7 +170,6 @@ for i in $(seq 1 20); do
   sleep 2
 done
 
-# Wait for services to reconnect
 sleep 5
 
 # ── Part C: System works after recovery ───────────────────────────────────────
@@ -162,7 +184,6 @@ assert_http "Checkout succeeds after order-redis recovery" "200" "$CODE"
 STATUS=$(json_field "$(get_body /orders/find/$ORDER3)" "status")
 assert_eq "Order marked paid after recovery" "paid" "$STATUS"
 
-# Switch back to saga for subsequent tests
 post "/orders/mode/saga" > /dev/null 2>&1
 
 summary
@@ -175,10 +196,6 @@ yellow "Checking wal-redis for orchestrator WAL keys after checkout..."
 ORCH_WAL_KEYS=$($WAL_CLI keys "wal:orch:*" 2>/dev/null | tr '\r\n' ' ')
 yellow "wal:orch:* keys found: ${ORCH_WAL_KEYS:-<none — completed batches cleaned up>}"
 
-# wal:orch:batch:* keys may have been cleaned up if the checkout completed
-# normally (complete_batch sets a 24h TTL and removes from pending).
-# So we check that wal-redis is responsive and that no orch WAL keys live
-# in mq-redis (where they must not be).
 MQ_CLI="docker compose exec -T mq-redis redis-cli -a redis --no-auth-warning"
 
 MISPLACED=$($MQ_CLI keys "wal:orch:*" 2>/dev/null | grep -v "^$" | head -5)
@@ -206,7 +223,6 @@ fi
 yellow "Restarting orchestrators..."
 docker compose start orchestrator-1 orchestrator-2 > /dev/null 2>&1
 
-# Wait for orchestrators to come back up and run recovery
 sleep 8
 
 yellow "Verifying checkout works after orchestrator restart (recovery ran)..."

--- a/test-scripts/run_all.sh
+++ b/test-scripts/run_all.sh
@@ -82,6 +82,7 @@ if [ "${SKIP_FAULT_TESTS:-0}" != "1" ]; then
   run_test "$SCRIPT_DIR/05_fault_app_replica.sh"
   run_test "$SCRIPT_DIR/06_fault_redis_master.sh"
   run_test "$SCRIPT_DIR/10_redis_aof_persistence.sh"
+  run_test "$SCRIPT_DIR/14_wal_decoupled.sh"
 else
   echo ""
   echo -e "${YELLOW}→  Skipping fault tests (SKIP_FAULT_TESTS=1)${RESET}"

--- a/test-scripts/test_orchestrator.py
+++ b/test-scripts/test_orchestrator.py
@@ -27,7 +27,7 @@ COMPOSE_PROJECT = "dds26-team16"
 ORCHESTRATOR_CTR_1 = f"{COMPOSE_PROJECT}-orchestrator-1-1"
 ORCHESTRATOR_CTR_2 = f"{COMPOSE_PROJECT}-orchestrator-2-1"
 ORCHESTRATOR_CTR = ORCHESTRATOR_CTR_1  # primary for single-container ops
-ORCH_REDIS_SENTINEL_CTR = f"{COMPOSE_PROJECT}-orch-redis-sentinel-1"
+WAL_REDIS_SENTINEL_CTR = f"{COMPOSE_PROJECT}-wal-redis-sentinel-1"
 
 
 # ── helpers ────────────────────────────────────────────────────────────────────
@@ -110,22 +110,22 @@ def docker_available() -> bool:
         return False
 
 
-def _orch_master_ip() -> str:
-    """Resolve the current orch-redis master IP via Sentinel."""
-    r = _docker("exec", ORCH_REDIS_SENTINEL_CTR,
-                "redis-cli", "-p", "26379", "sentinel", "get-master-addr-by-name", "orch-master")
+def _wal_master_ip() -> str:
+    """Resolve the current wal-redis master IP via Sentinel."""
+    r = _docker("exec", WAL_REDIS_SENTINEL_CTR,
+                "redis-cli", "-p", "26379", "sentinel", "get-master-addr-by-name", "wal-master")
     return r.stdout.strip().split('\n')[0]
 
 def orch_redis_cmd(*args) -> str:
-    """Run a redis-cli command against the current orch-redis master (Sentinel-aware)."""
-    master_ip = _orch_master_ip()
-    r = _docker("exec", ORCH_REDIS_SENTINEL_CTR,
+    """Run a redis-cli command against the current wal-redis master (Sentinel-aware)."""
+    master_ip = _wal_master_ip()
+    r = _docker("exec", WAL_REDIS_SENTINEL_CTR,
                 "redis-cli", "-h", master_ip, "-p", "6379", "-a", "redis", *args)
     return r.stdout.strip()
 
 
 def orch_pending_count() -> int:
-    out = orch_redis_cmd("SCARD", "orch:pending")
+    out = orch_redis_cmd("SCARD", "wal:orch:pending")
     try:
         return int(out)
     except ValueError:
@@ -415,7 +415,7 @@ class TestOrchestratorResilience(unittest.TestCase):
         time.sleep(1)
 
     def test_wal_empty_after_successful_checkout(self):
-        """orch:pending must be empty after a successful checkout completes."""
+        """wal:orch:pending must be empty after a successful checkout completes."""
         order_id, _, _ = make_shippable_order(price=10, stock=5, credit=50)
         r = checkout(order_id)
         self.assertTrue(ok(r), r.text)
@@ -423,7 +423,7 @@ class TestOrchestratorResilience(unittest.TestCase):
         # Give orchestrator a moment to clean up
         time.sleep(1)
         count = orch_pending_count()
-        self.assertEqual(count, 0, f"orch:pending should be empty, has {count} entries")
+        self.assertEqual(count, 0, f"wal:orch:pending should be empty, has {count} entries")
 
     def test_orchestrator_pause_resume_saga(self):
         """
@@ -477,7 +477,7 @@ class TestOrchestratorResilience(unittest.TestCase):
 
     def test_orchestrator_restart_clears_wal(self):
         """
-        Seed orch:pending with a fake completed batch (status=COMPLETED),
+        Seed wal:orch:pending with a fake completed batch (status=COMPLETED),
         restart the orchestrator, and verify it cleans up the stale WAL entry.
         This tests the 'already terminal → just srem' recovery path.
         """
@@ -490,8 +490,8 @@ class TestOrchestratorResilience(unittest.TestCase):
         })
 
         # Seed WAL directly
-        orch_redis_cmd("SADD", "orch:pending", fake_batch_id)
-        orch_redis_cmd("SET", f"orch:batch:{fake_batch_id}", fake_blob)
+        orch_redis_cmd("SADD", "wal:orch:pending", fake_batch_id)
+        orch_redis_cmd("SET", f"wal:orch:batch:{fake_batch_id}", fake_blob)
 
         self.assertEqual(orch_pending_count(), 1, "WAL seed failed")
 
@@ -500,11 +500,11 @@ class TestOrchestratorResilience(unittest.TestCase):
         time.sleep(1)  # let it start
 
         cleared = wait_for_orch_pending_empty(timeout=15)
-        self.assertTrue(cleared, "Orchestrator recovery did not clear completed batch from orch:pending")
+        self.assertTrue(cleared, "Orchestrator recovery did not clear completed batch from wal:orch:pending")
 
     def test_orchestrator_restart_reprocesses_pending_batch(self):
         """
-        Seed orch:pending with a RUNNING batch whose task is PENDING (not yet dispatched).
+        Seed wal:orch:pending with a RUNNING batch whose task is PENDING (not yet dispatched).
         Restart the orchestrator.  Recovery must dispatch the task and push a reply.
 
         This simulates: orchestrator crashed after writing WAL but before dispatching.
@@ -539,8 +539,8 @@ class TestOrchestratorResilience(unittest.TestCase):
             },
         })
 
-        orch_redis_cmd("SADD", "orch:pending", batch_id)
-        orch_redis_cmd("SET", f"orch:batch:{batch_id}", batch_blob)
+        orch_redis_cmd("SADD", "wal:orch:pending", batch_id)
+        orch_redis_cmd("SET", f"wal:orch:batch:{batch_id}", batch_blob)
 
         stock_before = find_item(item_id)["stock"]
 
@@ -577,7 +577,7 @@ class TestOrchestratorResilience(unittest.TestCase):
 
         self.assertEqual(find_item(item_id)["stock"],  final_stock,  "Stock changed after restart")
         self.assertEqual(find_user(user_id)["credit"], final_credit, "Credit changed after restart")
-        self.assertEqual(orch_pending_count(), 0, "orch:pending not empty after restarts")
+        self.assertEqual(orch_pending_count(), 0, "wal:orch:pending not empty after restarts")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
A single shared wal-redis cluster (master + replica + Sentinel, --appendfsync always) which stores WAL entries for all four services. Every service gets a dedicated wal.py module that opens an independent connection to this cluster. Business data writes and WAL writes never share a pipeline or a Redis instance.

Resolves #13 